### PR TITLE
FEAT: Upgrade to pydantic v2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - networkx
   - numpy
   - orjson
-  - pydantic<2
+  - pydantic>=2
   - pyyaml
   - pytables
   - tqdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "networkx",
   "numpy",
   "orjson",
-  "pydantic<2",
+  "pydantic>=2",
   "pyyaml",
   "tables",
   "tqdm",

--- a/sax/circuit.py
+++ b/sax/circuit.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypedDict, Unio
 import black
 import networkx as nx
 import numpy as np
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from sax import reciprocal
 from .backends import circuit_backends
 from .multimode import multimode, singlemode

--- a/sax/netlist.py
+++ b/sax/netlist.py
@@ -13,8 +13,8 @@ from typing import Any, Callable, Dict, Optional, Union
 import black
 import numpy as np
 import yaml
-from pydantic import BaseModel as _BaseModel
-from pydantic import Extra, Field, ValidationError, validator
+from pydantic.v1 import BaseModel as _BaseModel
+from pydantic.v1 import Extra, Field, ValidationError, validator
 from .utils import clean_string, get_settings, hash_dict
 
 # Internal Cell


### PR DESCRIPTION
Hi Floris,

Hope you are well - I love `sax` and cheers for creating such a great software!

I've been integrating it into my project, and ended up sorting out `pydantic v2` migrations as well for `gdsfactory` per https://github.com/gdsfactory/gdsfactory/pull/1718, and hence now `sax`. I've tried to run `pytest` to verify full integration but if you recommend any verification mechanism happy to do so too.

Just in case this is useful for the future when upgrading to `pydantic v2`! Note that I am unsure whether `pydantic` have implemented an automatic deployment of the v1 migration on their latest PyPi version, I had to run their `migration_v1.sh` local github script which I assume they will implement in the workflow. 