### PR TITLE
Allow for omitting placements in recursive netlist

### DIFF
--- a/sax/netlist.py
+++ b/sax/netlist.py
@@ -170,7 +170,9 @@ class Netlist(_BaseModel):
 
     @validator("placements")
     def validate_placement_names(cls, placements):
-        return {cls.clean_instance_string(k): v for k, v in placements.items()}
+        if placements is not None:
+            return {cls.clean_instance_string(k): v for k, v in placements.items()}
+        return {}
 
     @classmethod
     def clean_connection_string(cls, value):


### PR DESCRIPTION
It would be nice to be able to omit the "placements" key when writing a recursive netlist by hand or generating it from another tool that is not gdsfactory. Presently, passing at least an empty dictionary required because the default pydantic Field value is None:

```python
sub = {
    "instances": {
        "wg1": "long_waveguide",
        "wg2": "short_waveguide",
    },
    "connections": {
        'wg1,o1': 'wg2,o0'
    },
    "ports": {
        "in": "wg1,o0",
        "out": "wg2,o1",
    },
    "placements": {},
}

recnet = {
    "sub_overall": {
        "instances": {
            # define model names
            "sub1": "sub1",
            "sub2": "sub2",
        },
        "connections": {
            "sub1,out": "sub2,in",
        },
        "ports": {
            "in": "sub1,in",
            "out": "sub3,out",
        },
        "placements": {},
    },
    "sub1": sub,
    "sub2": sub,
}
```

This pull request makes the following modification:

```python
@validator("placements")
def validate_placement_names(cls, placements):
    # NEW: check if None (no value defined, default Pydantic value), return empty dictionary
    if placements is not None:
        return {cls.clean_instance_string(k): v for k, v in placements.items()}
    return {}
```