### PR TITLE
Pin min numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "matplotlib",
   "natsort",
   "networkx",
-  "numpy",
+  "numpy>=1.25.0",
   "orjson",
   "pydantic>=2.2",
   "pyyaml",


### PR DESCRIPTION
New import from ``numpy.exceptions`` requires ``numpy >= 1.25.0``.