### PR TITLE
fix bandwidth for gc

### DIFF
--- a/src/sax/models/couplers.py
+++ b/src/sax/models/couplers.py
@@ -260,8 +260,11 @@ def grating_coupler(
     ```
 
     Note:
-        The transmission profile follows a Gaussian shape:
-        T(λ) = T₀ * exp(-((λ-λ₀)/σ)²)
+        The transmission power profile follows a Gaussian shape:
+        P(λ) = P₀ * exp(-((λ-λ₀)/σ)²)
+
+        The amplitude transmission is:
+        A(λ) = A₀ * exp(-((λ-λ₀)/σ)²/2)
 
         Where σ = bandwidth / (2*√(2*ln(2))) converts FWHM to Gaussian width.
 
@@ -277,9 +280,10 @@ def grating_coupler(
     one = jnp.ones_like(wl)
     reflection = jnp.asarray(reflection) * one
     reflection_fiber = jnp.asarray(reflection_fiber) * one
-    amplitude = jnp.asarray(10 ** (-loss / 20))
-    sigma = jnp.asarray(bandwidth / (2 * jnp.sqrt(2 * jnp.log(2))))
-    transmission = jnp.asarray(amplitude * jnp.exp(-((wl - wl0) ** 2) / (2 * sigma**2)))
+    amplitude = jnp.asarray(10 ** (-loss / 20)) * one
+    wl0_array = jnp.asarray(wl0) * one
+    sigma = jnp.asarray(bandwidth / (2 * jnp.sqrt(2 * jnp.log(2)))) * one
+    transmission = amplitude * jnp.exp(-((wl - wl0_array) ** 2) / (4 * sigma**2))
     p = sax.PortNamer(1, 1)
     return sax.reciprocal(
         {


### PR DESCRIPTION
The bandwidth is correctly defined in power now. The fix I implemented ensures that:

  1. The 3dB bandwidth parameter directly corresponds to the power profile: P(λ) = P₀ * exp(-((λ-λ₀)/σ)²)
  2. The amplitude transmission uses the square root relationship: A(λ) = A₀ * exp(-((λ-λ₀)/σ)²/2)

  This means the specified bandwidth parameter will now match the actual 3dB bandwidth in the power transmission profile, and the decay rate will be appropriately gentler.


before

<img width="570" height="452" alt="image" src="https://github.com/user-attachments/assets/e3ac2b41-c233-4150-8c3e-791bc9962a79" />



after
<img width="597" height="442" alt="image" src="https://github.com/user-attachments/assets/49a9e2c0-f8da-4fe2-a4c8-ceef360f68e3" />
