### PR TITLE
Implement generic RF models

### DIFF
--- a/src/sax/models/rf.py
+++ b/src/sax/models/rf.py
@@ -1,0 +1,260 @@
+"""Sax generic RF models."""
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+from pydantic import validate_call
+
+import sax
+
+
+@partial(jax.jit, static_argnames=("n_ports"))
+@validate_call
+def gamma_0_load(
+    f: sax.FloatArrayLike = 5e9,
+    gamma_0: complex = 0,
+    n_ports: int = 1,
+) -> sax.SDict:
+    r"""Connection with given reflection coefficient.
+
+    Args:
+        f: Array of frequency points in Hz
+        gamma_0: Reflection coefficient Γ₀ of connection
+        n_ports: Number of ports in component. The diagonal ports of the matrix
+            are set to Γ₀ and the off-diagonal ports to 0.
+
+    Returns:
+        S-dictionary where :math:`S = \Gamma_0I_\text{n\_ports}`
+
+    Examples:
+        ```python
+        # mkdocs: render
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import sax
+
+        sax.set_port_naming_strategy("optical")
+
+        f = np.linspace(1e9, 10e9, 500)
+        gamma_0 = 0.5 * np.exp(1j * np.pi / 4)
+        s = sax.models.rf.gamma_0_load(f=f, gamma_0=gamma_0, n_ports=2)
+        plt.figure()
+        plt.plot(f / 1e9, np.abs(s[("o1", "o1")]), label="|S11|")
+        plt.plot(f / 1e9, np.abs(s[("o2", "o2")]), label="|S22|")
+        plt.plot(f / 1e9, np.abs(s[("o1", "o2")]), label="|S12|")
+        plt.plot(f / 1e9, np.abs(s[("o2", "o1")]), label="|S21|")
+        plt.xlabel("Frequency [GHz]")
+        plt.ylabel("Magnitude")
+        plt.legend()
+        ```
+    """
+    f = jnp.asarray(f)
+    sdict = {
+        (f"o{i}", f"o{i}"): jnp.full(len(f), gamma_0) for i in range(1, n_ports + 1)
+    }
+    sdict |= {
+        (f"o{i}", f"o{j}"): jnp.zeros(len(f), dtype=complex)
+        for i in range(1, n_ports + 1)
+        for j in range(i + 1, n_ports + 1)
+    }
+    return sax.reciprocal(sdict)
+
+
+@jax.jit
+def tee(f: sax.FloatArrayLike = 5e9) -> sax.SDict:
+    """Ideal three-port RF power divider/combiner (T-junction).
+
+    Args:
+        f: Array of frequency points in Hz
+
+    Returns:
+        S-dictionary representing ideal RF T-junction behavior
+
+    Examples:
+        ```python
+        # mkdocs: render
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import sax
+
+        sax.set_port_naming_strategy("optical")
+
+        f = np.linspace(1e9, 10e9, 500)
+        s = sax.models.rf.tee(f=f)
+        plt.figure()
+        plt.plot(f / 1e9, np.abs(s[("o1", "o2")]) ** 2, label="|S12|^2")
+        plt.plot(f / 1e9, np.abs(s[("o1", "o3")]) ** 2, label="|S13|^2")
+        plt.plot(f / 1e9, np.abs(s[("o2", "o3")]) ** 2, label="|S23|^2")
+        plt.xlabel("Frequency [GHz]")
+        plt.ylabel("Power")
+        plt.legend()
+        ```
+    """
+    f = jnp.asarray(f)
+    sdict = {(f"o{i}", f"o{i}"): jnp.full(len(f), -1 / 3) for i in range(1, 4)}
+    sdict |= {
+        (f"o{i}", f"o{j}"): jnp.full(len(f), 2 / 3)
+        for i in range(1, 4)
+        for j in range(i + 1, 4)
+    }
+    return sax.reciprocal(sdict)
+
+
+@jax.jit
+def impedance(z: complex = 50, z0: complex = 50) -> sax.SDict:
+    r"""Generalized two-port impedance element.
+
+    Args:
+        z: Impedance in Ω
+        z0: Reference impedance in Ω.
+
+    Returns:
+        S-dictionary representing the impedance element
+
+    Examples:
+        ```python
+        # mkdocs: render
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import sax
+
+        sax.set_port_naming_strategy("optical")
+
+        f = np.linspace(1e9, 10e9, 500)
+        s = sax.models.rf.impedance(z=75, z0=50)
+        plt.figure()
+        plt.plot(f / 1e9, np.abs(s[("o1", "o1")]), label="|S11|")
+        plt.plot(f / 1e9, np.abs(s[("o1", "o2")]), label="|S12|")
+        plt.plot(f / 1e9, np.abs(s[("o2", "o2")]), label="|S22|")
+        plt.xlabel("Frequency [GHz]")
+        plt.ylabel("Magnitude")
+        plt.legend()
+        ```
+    """
+    sdict = {
+        ("o1", "o1"): jnp.asarray(z / (z + 2 * z0)),
+        ("o1", "o2"): jnp.asarray(2 * z0 / (2 * z0 + z)),
+        ("o2", "o2"): jnp.asarray(z / (z + 2 * z0)),
+    }
+    return sax.reciprocal(sdict)
+
+
+@jax.jit
+def admittance(y: complex = 1 / 50) -> sax.SDict:
+    r"""Generalized two-port admittance element.
+
+    Args:
+        y: Admittance in siemens
+
+    Returns:
+        S-dictionary representing the admittance element
+
+    Examples:
+        ```python
+        # mkdocs: render
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import sax
+
+        sax.set_port_naming_strategy("optical")
+
+        f = np.linspace(1e9, 10e9, 500)
+        s = sax.models.rf.admittance(y=1 / 75)
+        plt.figure()
+        plt.plot(f / 1e9, np.abs(s[("o1", "o1")]), label="|S11|")
+        plt.plot(f / 1e9, np.abs(s[("o1", "o2")]), label="|S12|")
+        plt.plot(f / 1e9, np.abs(s[("o2", "o2")]), label="|S22|")
+        plt.xlabel("Frequency [GHz]")
+        plt.ylabel("Magnitude")
+        plt.legend()
+        ```
+    """
+    sdict = {
+        ("o1", "o1"): jnp.asarray(1 / (1 + y)),
+        ("o1", "o2"): jnp.asarray(y / (1 + y)),
+        ("o2", "o2"): jnp.asarray(1 / (1 + y)),
+    }
+    return sax.reciprocal(sdict)
+
+
+@jax.jit
+def capacitor(
+    f: sax.FloatArrayLike = 5e9,
+    capacitance: float = 1e-15,
+    z0: complex = 50,
+) -> sax.SDict:
+    r"""Ideal two-port capacitor model.
+
+    Args:
+        f: Frequency in Hz
+        capacitance: Capacitance in Farads
+        z0: Reference impedance in Ω.
+
+    Returns:
+        S-dictionary representing the capacitor element
+
+    Examples:
+        ```python
+        # mkdocs: render
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import sax
+
+        sax.set_port_naming_strategy("optical")
+
+        f = np.linspace(1e9, 10e9, 500)
+        s = sax.models.rf.capacitor(f=f, capacitance=1e-12, z0=50)
+        plt.figure()
+        plt.plot(f / 1e9, np.abs(s[("o1", "o1")]), label="|S11|")
+        plt.plot(f / 1e9, np.abs(s[("o1", "o2")]), label="|S12|")
+        plt.plot(f / 1e9, np.abs(s[("o2", "o2")]), label="|S22|")
+        plt.xlabel("Frequency [GHz]")
+        plt.ylabel("Magnitude")
+        plt.legend()
+        ```
+    """
+    angular_frequency = 2 * jnp.pi * jnp.asarray(f)
+    capacitor_impedance = 1 / (1j * angular_frequency * capacitance)
+    return impedance(z=capacitor_impedance, z0=z0)
+
+
+@jax.jit
+def inductor(
+    f: sax.FloatArrayLike = 5e9,
+    inductance: float = 1e-12,
+    z0: complex = 50,
+) -> sax.SDict:
+    r"""Ideal two-port inductor model.
+
+    Args:
+        f: Frequency in Hz
+        inductance: Inductance in Henries
+        z0: Reference impedance in Ω.
+
+    Returns:
+        S-dictionary representing the inductor element
+
+    Examples:
+        ```python
+        # mkdocs: render
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import sax
+
+        sax.set_port_naming_strategy("optical")
+
+        f = np.linspace(1e9, 10e9, 500)
+        s = sax.models.rf.inductor(f=f, inductance=1e-9, z0=50)
+        plt.figure()
+        plt.plot(f / 1e9, np.abs(s[("o1", "o1")]), label="|S11|")
+        plt.plot(f / 1e9, np.abs(s[("o1", "o2")]), label="|S12|")
+        plt.plot(f / 1e9, np.abs(s[("o2", "o2")]), label="|S22|")
+        plt.xlabel("Frequency [GHz]")
+        plt.ylabel("Magnitude")
+        plt.legend()
+        ```
+    """
+    angular_frequency = 2 * jnp.pi * jnp.asarray(f)
+    inductor_impedance = 1j * angular_frequency * inductance
+    return impedance(z=inductor_impedance, z0=z0)

--- a/src/sax/models/rf.py
+++ b/src/sax/models/rf.py
@@ -13,8 +13,8 @@ import sax
 @validate_call
 def gamma_0_load(
     f: sax.FloatArrayLike = 5e9,
-    gamma_0: complex = 0,
-    n_ports: int = 1,
+    gamma_0: sax.ComplexLike = 0,
+    n_ports: sax.IntLike = 1,
 ) -> sax.SDict:
     r"""Connection with given reflection coefficient.
 
@@ -62,6 +62,7 @@ def gamma_0_load(
 
 
 @jax.jit
+@validate_call
 def tee(f: sax.FloatArrayLike = 5e9) -> sax.SDict:
     """Ideal three-port RF power divider/combiner (T-junction).
 
@@ -102,7 +103,8 @@ def tee(f: sax.FloatArrayLike = 5e9) -> sax.SDict:
 
 
 @jax.jit
-def impedance(z: complex = 50, z0: complex = 50) -> sax.SDict:
+@validate_call
+def impedance(z: sax.ComplexLike = 50, z0: sax.ComplexLike = 50) -> sax.SDict:
     r"""Generalized two-port impedance element.
 
     Args:
@@ -141,7 +143,8 @@ def impedance(z: complex = 50, z0: complex = 50) -> sax.SDict:
 
 
 @jax.jit
-def admittance(y: complex = 1 / 50) -> sax.SDict:
+@validate_call
+def admittance(y: sax.ComplexLike = 1 / 50) -> sax.SDict:
     r"""Generalized two-port admittance element.
 
     Args:
@@ -179,10 +182,11 @@ def admittance(y: complex = 1 / 50) -> sax.SDict:
 
 
 @jax.jit
+@validate_call
 def capacitor(
     f: sax.FloatArrayLike = 5e9,
-    capacitance: float = 1e-15,
-    z0: complex = 50,
+    capacitance: sax.FloatLike = 1e-15,
+    z0: sax.ComplexLike = 50,
 ) -> sax.SDict:
     r"""Ideal two-port capacitor model.
 
@@ -220,10 +224,11 @@ def capacitor(
 
 
 @jax.jit
+@validate_call
 def inductor(
     f: sax.FloatArrayLike = 5e9,
-    inductance: float = 1e-12,
-    z0: complex = 50,
+    inductance: sax.FloatLike = 1e-12,
+    z0: sax.ComplexLike = 50,
 ) -> sax.SDict:
     r"""Ideal two-port inductor model.
 

--- a/src/tests/test_rf_models.py
+++ b/src/tests/test_rf_models.py
@@ -1,0 +1,82 @@
+import jax.numpy as jnp
+import pytest
+
+from sax.models import rf
+
+
+class TestRFModels:
+    """Test suite for RF model components."""
+
+    @pytest.fixture
+    def freq_array(self) -> jnp.ndarray:
+        """Frequency array fixture."""
+        return jnp.linspace(1e9, 10e9, 10)
+
+    @pytest.fixture
+    def freq_single(self) -> float:
+        """Single frequency fixture."""
+        return 1e9
+
+    @staticmethod
+    def _assert_s_params_dict(s: dict, expected_shape: tuple | None = None) -> None:
+        """Helper method to assert common S-parameter dictionary properties."""
+        assert isinstance(s, dict)
+        if expected_shape is not None:
+            assert s[("o1", "o1")].shape == expected_shape
+
+    @staticmethod
+    def _assert_s_param(s: dict, port_pair: tuple, expected_value: complex) -> None:
+        """Helper method to assert a specific S-parameter value."""
+        assert jnp.allclose(s[port_pair], expected_value)
+
+    def test_gamma_0_load(self, freq_array: jnp.ndarray) -> None:
+        """Test gamma_0_load with frequency array."""
+        s = rf.gamma_0_load(f=freq_array, gamma_0=0.5, n_ports=2)
+
+        self._assert_s_params_dict(s, expected_shape=(10,))
+        self._assert_s_param(s, ("o1", "o1"), 0.5)
+        self._assert_s_param(s, ("o1", "o2"), 0)
+
+    def test_tee(self, freq_array: jnp.ndarray) -> None:
+        """Test tee splitter."""
+        s = rf.tee(f=freq_array)
+
+        self._assert_s_params_dict(s, expected_shape=(10,))
+        self._assert_s_param(s, ("o1", "o1"), -1 / 3)
+        self._assert_s_param(s, ("o1", "o2"), 2 / 3)
+
+    def test_impedance(self) -> None:
+        """Test impedance element."""
+        s = rf.impedance(z=75, z0=50)
+
+        self._assert_s_params_dict(s)
+        self._assert_s_param(s, ("o1", "o1"), 75 / (75 + 100))
+
+    def test_admittance(self) -> None:
+        """Test admittance element."""
+        s = rf.admittance(y=1 / 75)
+
+        self._assert_s_params_dict(s)
+        self._assert_s_param(s, ("o1", "o1"), 1 / (1 + 1 / 75))
+
+    def test_capacitor(self, freq_single: float) -> None:
+        """Test capacitor element."""
+        s = rf.capacitor(f=freq_single, capacitance=1e-12, z0=50)
+
+        self._assert_s_params_dict(s)
+
+        angular_frequency = 2 * jnp.pi * freq_single
+        capacitor_impedance = 1 / (1j * angular_frequency * 1e-12)
+        expected_s11 = capacitor_impedance / (capacitor_impedance + 100)
+        self._assert_s_param(s, ("o1", "o1"), expected_s11)
+
+    def test_inductor(self, freq_single: float) -> None:
+        """Test inductor element."""
+        s = rf.inductor(f=freq_single, inductance=1e-9, z0=50)
+
+        self._assert_s_params_dict(s)
+
+        angular_frequency = 2 * jnp.pi * freq_single
+        inductor_impedance = 1j * angular_frequency * 1e-9
+        expected_s11 = inductor_impedance / (inductor_impedance + 100)
+        self._assert_s_param(s, ("o1", "o1"), expected_s11)


### PR DESCRIPTION
This PR introduces generic RF S-parameter models for common components like capacitors, inductors, and impedance/admittance elements. These models are added to a new file `src/sax/models/rf.py` to keep them separate from existing photonic models. They are modified from https://github.com/gdsfactory/quantum-rf-pdk.

## Details
   - Implementation of gamma_0_load, tee, impedance, admittance, capacitor, and inductor models.

Closes #69