### PR TITLE
Specify dev. deps. in `just test` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Just
         uses: taiki-e/install-action@just
       - name: Run tests
-        run: just dev test
+        run: just test
       - name: Upload artifacts [tests]
         uses: actions/upload-artifact@master
         with:

--- a/justfile
+++ b/justfile
@@ -14,10 +14,10 @@ inits:
   cd src/sax && uv run mkinit --relative --recursive --write && uv run ruff format __init__.py
 
 ipykernel:
-  uv run python -m ipykernel install --user --name sax --display-name sax
+  uv run --extra dev python -m ipykernel install --user --name sax --display-name sax
 
 test: ipykernel
-  uv run pytest -s -n logical
+  uv run --extra dev pytest -s -n logical
 
 docs:
   sed 's|](docs/|](|g' README.md > docs/index.md


### PR DESCRIPTION
We may avoid explicitly installing dependencies if we specify them to be required by the uv command. This allows simplifying the command to run in CI.
