### PR TITLE
Support 1-port circuits

### DIFF
--- a/src/sax/circuits.py
+++ b/src/sax/circuits.py
@@ -606,10 +606,10 @@ def _validate_netlist_ports(netlist: sax.RecursiveNetlist) -> None:
     ports_str = ", ".join(list(top_level["ports"]))
     if not ports_str:
         ports_str = "no ports given"
-    if len(top_level["ports"]) < 2:
+    if len(top_level["ports"]) < 1:
         msg = (
             "Cannot create circuit: "
-            f"at least 2 ports need to be defined. Got {ports_str}."
+            f"at least 1 port needs to be defined. Got {ports_str}."
         )
         raise ValueError(msg)
 

--- a/src/sax/saxtypes/netlist.py
+++ b/src/sax/saxtypes/netlist.py
@@ -353,8 +353,7 @@ def val_recnet(obj: Any) -> RecursiveNetlist:
             continue
         if len(net.get("ports", {})) < 1:
             msg = (
-                f"Netlist {name!r} has no ports defined. "
-                "This netlist will be ignored."
+                f"Netlist {name!r} has no ports defined. This netlist will be ignored."
             )
             warnings.warn(msg, stacklevel=2)
             continue

--- a/src/sax/saxtypes/netlist.py
+++ b/src/sax/saxtypes/netlist.py
@@ -205,7 +205,7 @@ Connections: TypeAlias = dict[InstancePort, InstancePort]
 def val_ports(obj: Any) -> Ports:
     """Validate a ports definition for a netlist.
 
-    Ensures that at least one port is defined (minimum for a meaningful circuit).
+    Ensures that at least one port is defined.
 
     Args:
         obj: The object to validate as a ports definition.

--- a/src/sax/saxtypes/netlist.py
+++ b/src/sax/saxtypes/netlist.py
@@ -205,7 +205,7 @@ Connections: TypeAlias = dict[InstancePort, InstancePort]
 def val_ports(obj: Any) -> Ports:
     """Validate a ports definition for a netlist.
 
-    Ensures that at least two ports are defined (minimum for a meaningful circuit).
+    Ensures that at least one port is defined (minimum for a meaningful circuit).
 
     Args:
         obj: The object to validate as a ports definition.
@@ -214,7 +214,7 @@ def val_ports(obj: Any) -> Ports:
         The validated ports mapping.
 
     Raises:
-        TypeError: If fewer than two ports are defined.
+        TypeError: If no ports are defined.
 
     Examples:
         Validate a ports definition for a netlist:
@@ -229,8 +229,8 @@ def val_ports(obj: Any) -> Ports:
     from .into import into
 
     ports: dict[str, InstancePort] = into[dict[str, InstancePort]](obj)
-    if len(ports) < 2:
-        msg = "A sax netlist needs to have at least two ports defined."
+    if len(ports) < 1:
+        msg = "A sax netlist needs to have at least one port defined."
         raise TypeError(msg)
     return ports
 
@@ -351,9 +351,9 @@ def val_recnet(obj: Any) -> RecursiveNetlist:
             )
             warnings.warn(msg, stacklevel=2)
             continue
-        if len(net.get("ports", {})) < 2:
+        if len(net.get("ports", {})) < 1:
             msg = (
-                f"Netlist {name!r} has fewer than two ports defined. "
+                f"Netlist {name!r} has no ports defined. "
                 "This netlist will be ignored."
             )
             warnings.warn(msg, stacklevel=2)

--- a/src/tests/test_circuit.py
+++ b/src/tests/test_circuit.py
@@ -63,4 +63,3 @@ def test_1port_circuit() -> None:
 if __name__ == "__main__":
     print(test_circuit())
     print(test_1port_circuit())
-

--- a/src/tests/test_circuit.py
+++ b/src/tests/test_circuit.py
@@ -32,5 +32,35 @@ def test_circuit() -> None:
     )
 
 
+def test_1port_circuit() -> None:
+    """Test that 1-port circuits are supported."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+        },
+        "connections": {},
+        "ports": {
+            "in": "wg1,in0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    circuit, info = sax.circuit(netlist, models)
+    result = circuit()
+
+    # Verify the circuit has exactly 1 port
+    ports = sax.get_ports(result)
+    assert len(ports) == 1
+    assert "in" in ports
+
+    # Verify the S-matrix has the expected structure
+    assert ("in", "in") in result
+
+
 if __name__ == "__main__":
     print(test_circuit())
+    print(test_1port_circuit())
+

--- a/src/tests/test_circuit.py
+++ b/src/tests/test_circuit.py
@@ -48,7 +48,7 @@ def test_1port_circuit() -> None:
         "waveguide": sax.models.straight,
     }
 
-    circuit, info = sax.circuit(netlist, models)
+    circuit, _info = sax.circuit(netlist, models)
     result = circuit()
 
     # Verify the circuit has exactly 1 port


### PR DESCRIPTION
Allow 1-port circuits in SAX. This makes it easier to define RF circuits such as typical shunted shorted stubs.

Changes done with Copilot.

## Changes Made

1. **src/sax/circuits.py**: Modified `_validate_netlist_ports` to require at least 1 port instead of 2
2. **src/sax/saxtypes/netlist.py**: Updated two validation functions:
   - `val_ports`: Changed minimum from 2 to 1 port
   - `val_recnet`: Updated warning message to reflect 1-port minimum
3. **src/tests/test_circuit.py**: Added comprehensive test for 1-port circuits

## Verification

- [x] All changes made
- [x] Tests pass (test_circuit and test_1port_circuit)
- [x] Pre-commit hooks applied successfully
- [x] Code formatting fixed (ruff-format, end-of-file-fixer)
- [x] Security checks passed

## Testing

The implementation has been validated with:
- 1-port circuits (new functionality)
- 2-port circuits (backward compatibility)
- 4-port circuits (complex circuits like MZI)

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> Support 1-port Circuits


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/nikosavola/sax/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
