### PR TITLE
Add electrical_short and electrical_open RF models

### DIFF
--- a/src/sax/models/rf.py
+++ b/src/sax/models/rf.py
@@ -274,3 +274,46 @@ def inductor(
     angular_frequency = 2 * jnp.pi * jnp.asarray(f)
     inductor_impedance = 1j * angular_frequency * inductance
     return impedance(f=f, z=inductor_impedance, z0=z0)
+
+
+@partial(jax.jit, inline=True, static_argnames=("n_ports"))
+def electrical_short(
+    f: sax.FloatArrayLike = 5e9,
+    n_ports: int = 1,
+) -> sax.SDict:
+    r"""Electrical short connection Sax model.
+
+    Args:
+        f: Array of frequency points in Hz
+        n_ports: Number of ports to set as shorted
+
+    Returns:
+        S-dictionary where :math:`S = -I_\text{n\_ports}`
+
+    References:
+        [@pozar2012]
+    """
+    return gamma_0_load(f=f, gamma_0=-1, n_ports=n_ports)
+
+
+@partial(jax.jit, inline=True, static_argnames=("n_ports"))
+def electrical_open(
+    f: sax.FloatArrayLike = 5e9,
+    n_ports: int = 1,
+) -> sax.SDict:
+    r"""Electrical open connection Sax model.
+
+    Useful for specifying some ports to remain open while not exposing
+    them for connections in circuits.
+
+    Args:
+        f: Array of frequency points in Hz
+        n_ports: Number of ports to set as opened
+
+    Returns:
+        S-dictionary where :math:`S = I_\text{n\_ports}`
+
+    References:
+        [@pozar2012]
+    """
+    return gamma_0_load(f=f, gamma_0=1, n_ports=n_ports)

--- a/src/tests/test_rf_models.py
+++ b/src/tests/test_rf_models.py
@@ -33,7 +33,7 @@ class TestRFModels:
         """Test gamma_0_load with frequency array."""
         s = rf.gamma_0_load(f=freq_array, gamma_0=0.5, n_ports=2)
 
-        self._assert_s_params_dict(s, expected_shape=(10,))
+        self._assert_s_params_dict(s, expected_shape=(len(freq_array),))
         self._assert_s_param(s, ("o1", "o1"), 0.5)
         self._assert_s_param(s, ("o1", "o2"), 0)
 
@@ -41,7 +41,7 @@ class TestRFModels:
         """Test tee splitter."""
         s = rf.tee(f=freq_array)
 
-        self._assert_s_params_dict(s, expected_shape=(10,))
+        self._assert_s_params_dict(s, expected_shape=(len(freq_array),))
         self._assert_s_param(s, ("o1", "o1"), -1 / 3)
         self._assert_s_param(s, ("o1", "o2"), 2 / 3)
 
@@ -80,3 +80,21 @@ class TestRFModels:
         inductor_impedance = 1j * angular_frequency * 1e-9
         expected_s11 = inductor_impedance / (inductor_impedance + 100)
         self._assert_s_param(s, ("o1", "o1"), expected_s11)
+
+    def test_electrical_short(self, freq_array: jnp.ndarray) -> None:
+        """Test electrical_short with frequency array."""
+        s = rf.electrical_short(f=freq_array, n_ports=2)
+
+        self._assert_s_params_dict(s, expected_shape=(len(freq_array),))
+        self._assert_s_param(s, ("o1", "o1"), -1)
+        self._assert_s_param(s, ("o2", "o2"), -1)
+        self._assert_s_param(s, ("o1", "o2"), 0)
+
+    def test_electrical_open(self, freq_array: jnp.ndarray) -> None:
+        """Test electrical_open with frequency array."""
+        s = rf.electrical_open(f=freq_array, n_ports=2)
+
+        self._assert_s_params_dict(s, expected_shape=(len(freq_array),))
+        self._assert_s_param(s, ("o1", "o1"), 1)
+        self._assert_s_param(s, ("o2", "o2"), 1)
+        self._assert_s_param(s, ("o1", "o2"), 0)

--- a/src/tests/test_rf_models.py
+++ b/src/tests/test_rf_models.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import jax.numpy as jnp
 import pytest
 
@@ -81,20 +83,22 @@ class TestRFModels:
         expected_s11 = inductor_impedance / (inductor_impedance + 100)
         self._assert_s_param(s, ("o1", "o1"), expected_s11)
 
-    def test_electrical_short(self, freq_array: jnp.ndarray) -> None:
+    @pytest.mark.parametrize("n_ports", [1, 2, 3])
+    def test_electrical_short(self, freq_array: jnp.ndarray, n_ports: int) -> None:
         """Test electrical_short with frequency array."""
-        s = rf.electrical_short(f=freq_array, n_ports=2)
+        s = rf.electrical_short(f=freq_array, n_ports=n_ports)
 
         self._assert_s_params_dict(s, expected_shape=(len(freq_array),))
-        self._assert_s_param(s, ("o1", "o1"), -1)
-        self._assert_s_param(s, ("o2", "o2"), -1)
-        self._assert_s_param(s, ("o1", "o2"), 0)
+        for i, j in product(range(1, n_ports + 1), repeat=2):
+            expected_value = -1 if i == j else 0
+            self._assert_s_param(s, (f"o{i}", f"o{j}"), expected_value)
 
-    def test_electrical_open(self, freq_array: jnp.ndarray) -> None:
+    @pytest.mark.parametrize("n_ports", [1, 2, 3])
+    def test_electrical_open(self, freq_array: jnp.ndarray, n_ports: int) -> None:
         """Test electrical_open with frequency array."""
-        s = rf.electrical_open(f=freq_array, n_ports=2)
+        s = rf.electrical_open(f=freq_array, n_ports=n_ports)
 
         self._assert_s_params_dict(s, expected_shape=(len(freq_array),))
-        self._assert_s_param(s, ("o1", "o1"), 1)
-        self._assert_s_param(s, ("o2", "o2"), 1)
-        self._assert_s_param(s, ("o1", "o2"), 0)
+        for i, j in product(range(1, n_ports + 1), repeat=2):
+            expected_value = 1 if i == j else 0
+            self._assert_s_param(s, (f"o{i}", f"o{j}"), expected_value)


### PR DESCRIPTION
This pull request introduces `electrical_short` and `electrical_open` RF models now that 1-port circuits are supported after #74.