### PR TITLE
Add probes feature for circuit measurement taps

### DIFF
--- a/PLAN_probes.md
+++ b/PLAN_probes.md
@@ -1,0 +1,241 @@
+# Design Plan: Probes Feature for SAX
+
+## Overview
+
+Add a `probes` keyword argument to the `circuit()` function that allows inserting ideal 4-port measurement taps at connection points. Each probe intercepts a connection and exposes forward (`_fwd`) and backward (`_bwd`) traveling wave ports.
+
+**Design Decision:** Probes are passed as a `circuit()` argument rather than added to the netlist schema. This keeps the netlist schema compatible with GDSFactory and treats probes as a simulation-time debugging feature rather than part of the circuit definition.
+
+## User-Facing API
+
+### Circuit Call with Probes
+
+```python
+netlist = {
+    "instances": {
+        "wg1": "waveguide",
+        "wg2": "waveguide",
+    },
+    "connections": {
+        "wg1,out": "wg2,in",  # Connection to be probed
+    },
+    "ports": {
+        "in": "wg1,in",
+        "out": "wg2,out",
+    },
+}
+
+circuit_fn, info = sax.circuit(
+    netlist,
+    models=models,
+    probes={"mid": "wg1,out"},  # Probe named "mid" at connection "wg1,out"
+)
+```
+
+### Result
+
+The circuit will have ports: `in`, `out`, `mid_fwd`, `mid_bwd`
+
+- `mid_fwd`: Signal traveling from `wg1,out` toward `wg2,in`
+- `mid_bwd`: Signal traveling from `wg2,in` toward `wg1,out`
+
+## The Ideal Probe Model (4-port)
+
+```
+          in ─────────────────── out
+           │                     │
+           │     (ideal tap)     │
+           │                     │
+         tap_bwd               tap_fwd
+```
+
+### S-Matrix Definition
+
+An ideal directional coupler with 100% transmission AND 100% tap coupling (unphysical but useful for measurement):
+
+```python
+def ideal_probe() -> sax.SDict:
+    """Ideal 4-port probe: 100% transmission, 100% tap coupling."""
+    return {
+        # Through path: full transmission
+        ("in", "out"): 1.0,
+        ("out", "in"): 1.0,
+
+        # Forward tap: copies signal from in→out direction
+        ("in", "tap_fwd"): 1.0,
+        ("tap_fwd", "in"): 1.0,
+
+        # Backward tap: copies signal from out→in direction
+        ("out", "tap_bwd"): 1.0,
+        ("tap_bwd", "out"): 1.0,
+
+        # No cross-coupling between taps
+        ("tap_fwd", "tap_bwd"): 0.0,
+        ("tap_bwd", "tap_fwd"): 0.0,
+
+        # No coupling from taps back to main path (unidirectional taps)
+        ("tap_fwd", "out"): 0.0,
+        ("tap_bwd", "in"): 0.0,
+
+        # No reflections
+        ("in", "in"): 0.0,
+        ("out", "out"): 0.0,
+        ("tap_fwd", "tap_fwd"): 0.0,
+        ("tap_bwd", "tap_bwd"): 0.0,
+    }
+```
+
+**Note:** This S-matrix is NOT unitary (violates energy conservation). This is intentional—it's a measurement tool, not a physical device.
+
+## Internal Transformation
+
+When processing the netlist, the `probes` section triggers a transformation:
+
+### Before (user-provided):
+```python
+{
+    "instances": {"wg1": "waveguide", "wg2": "waveguide"},
+    "connections": {"wg1,out": "wg2,in"},
+    "ports": {"in": "wg1,in", "out": "wg2,out"},
+    "probes": {"mid": "wg1,out"},
+}
+```
+
+### After (internal):
+```python
+{
+    "instances": {
+        "wg1": "waveguide",
+        "wg2": "waveguide",
+        "_probe_mid": {"component": "_ideal_probe"},
+    },
+    "connections": {
+        "wg1,out": "_probe_mid,in",
+        "_probe_mid,out": "wg2,in",
+    },
+    "ports": {
+        "in": "wg1,in",
+        "out": "wg2,out",
+        "mid_fwd": "_probe_mid,tap_fwd",
+        "mid_bwd": "_probe_mid,tap_bwd",
+    },
+    # probes section removed after processing
+}
+```
+
+## Implementation Plan
+
+### 1. Add Ideal Probe Model (`src/sax/models/probes.py`)
+
+Create a new file with the `ideal_probe` model function.
+
+### 2. Add Probe Expansion Logic (`src/sax/netlists.py`)
+
+```python
+def expand_probes(
+    netlist: sax.Netlist,
+    probes: dict[str, str],
+) -> sax.Netlist:
+    """Expand probes into ideal_probe instances and update connections/ports."""
+```
+
+This function:
+1. For each probe name → instance_port mapping:
+   - Validate the instance_port is part of a connection
+   - Find the connection containing this instance_port
+   - Insert `_probe_{name}` instance
+   - Split the connection: `a,p1 → b,p2` becomes `a,p1 → _probe_{name},in` and `_probe_{name},out → b,p2`
+   - Add ports: `{name}_fwd → _probe_{name},tap_fwd` and `{name}_bwd → _probe_{name},tap_bwd`
+2. Return the modified netlist
+
+### 3. Integrate into Circuit Compilation (`src/sax/circuits.py`)
+
+Add `probes` parameter to the `circuit()` function signature:
+
+```python
+def circuit(
+    netlist: sax.AnyNetlist,
+    models: sax.Models | None = None,
+    *,
+    backend: sax.BackendLike = "default",
+    return_type: Literal["SDict", "SDense", "SCoo"] = "SDict",
+    top_level_name: str = "top_level",
+    ignore_impossible_connections: bool = False,
+    probes: dict[str, str] | None = None,  # NEW
+) -> tuple[sax.Model, sax.CircuitInfo]:
+```
+
+In the function body, after `convert_nets_to_connections()` and before `resolve_array_instances()`:
+
+```python
+recnet = convert_nets_to_connections(recnet)
+if probes:
+    recnet = expand_probes(recnet, probes)  # NEW
+    models = {"_ideal_probe": ideal_probe, **(models or {})}  # Inject probe model
+recnet = resolve_array_instances(recnet)
+```
+
+### 4. Update Exports
+
+- Add `ideal_probe` to `sax.models` exports
+- Optionally add `expand_probes` to `sax.netlists` exports (could remain internal)
+
+### 5. Add Tests (`src/tests/test_probes.py`)
+
+Test cases:
+1. Basic probe insertion on a simple 2-waveguide circuit
+2. Multiple probes on different connections
+3. Probe on a connection in a more complex circuit
+4. Error case: probe on non-existent instance port
+5. Error case: probe on instance port not part of any connection
+6. Verify S-matrix values at probe ports
+
+### 6. Add Documentation/Example
+
+Consider adding an example notebook demonstrating probe usage.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/sax/models/probes.py` | NEW: `ideal_probe()` model |
+| `src/sax/models/__init__.py` | Export `ideal_probe` |
+| `src/sax/netlists.py` | Add `expand_probes()` function |
+| `src/sax/circuits.py` | Add `probes` parameter, call `expand_probes()`, inject probe model |
+| `src/tests/test_probes.py` | NEW: test cases |
+
+## Edge Cases & Validation
+
+1. **Probe on non-connected port**: Error - "Probe 'X' references instance port 'Y' which is not part of any connection"
+
+2. **Duplicate probe names**: Handled naturally by dict (last one wins), but could warn
+
+3. **Probe name conflicts with existing ports**: Error - "Probe 'X' would create ports 'X_fwd'/'X_bwd' which conflict with existing ports"
+
+4. **Probe instance name conflicts**: Use `_probe_` prefix to minimize conflicts; if conflict exists, error
+
+5. **Hierarchical netlists**: Probes are expanded on the top-level netlist only (after flattening conceptually). This is handled naturally since `expand_probes` operates on the recursive netlist before sub-circuits are resolved.
+
+6. **Empty probes dict**: No-op, just return netlist unchanged
+
+## Open Questions
+
+1. **Naming convention**: `mid_fwd`/`mid_bwd` vs `mid@fwd`/`mid@bwd` vs `mid:fwd`/`mid:bwd`?
+   - Recommendation: `_fwd`/`_bwd` suffix is simple and avoids special characters
+
+2. **Should probes accept parameters?** (e.g., partial coupling for more realistic taps)
+   - Recommendation: Start simple with ideal probes; can add `probe_settings` later if needed
+
+3. **Multimode support**: Should probes work with multimode simulations?
+   - Recommendation: Yes, the transformation happens before multimode expansion, so it should work automatically
+
+4. **Should we allow probes on external ports?** (ports that connect to the outside)
+   - Recommendation: No, only on internal connections. External ports are already observable.
+
+## Benefits of This Approach
+
+1. **GDSFactory compatibility**: Netlist schema is unchanged
+2. **Separation of concerns**: Physical circuit definition vs simulation debugging
+3. **Flexibility**: Same netlist can be simulated with or without probes
+4. **Non-invasive**: Probes don't get saved to YAML/JSON files (they're transient)
+5. **Simple API**: Just one new keyword argument to `circuit()`

--- a/nbs/examples/14_probes.ipynb
+++ b/nbs/examples/14_probes.ipynb
@@ -1,0 +1,486 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Probes\n",
+    "> Measure intermediate signals in circuits using ideal measurement probes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "When debugging or analyzing complex circuits, it's often useful to observe the signal at intermediate points—not just at the external ports. SAX provides a `probes` feature that allows you to insert ideal measurement taps at any connection point in your circuit.\n",
+    "\n",
+    "Each probe is an unphysical 4-port device with:\n",
+    "- 100% transmission through the main path\n",
+    "- 100% coupling to forward and backward tap ports\n",
+    "\n",
+    "This allows you to \"see\" what's happening inside your circuit without affecting the signal propagation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import sax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Define Component Models\n",
+    "\n",
+    "Let's define simple coupler and waveguide models, similar to the quick start example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def coupler(coupling=0.5) -> sax.SDict:\n",
+    "    kappa = coupling**0.5\n",
+    "    tau = (1 - coupling) ** 0.5\n",
+    "    return sax.reciprocal(\n",
+    "        {\n",
+    "            (\"in0\", \"out0\"): tau,\n",
+    "            (\"in0\", \"out1\"): 1j * kappa,\n",
+    "            (\"in1\", \"out0\"): 1j * kappa,\n",
+    "            (\"in1\", \"out1\"): tau,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def waveguide(wl=1.55, wl0=1.55, neff=2.34, ng=3.4, length=10.0, loss=0.0) -> sax.SDict:\n",
+    "    dwl = wl - wl0\n",
+    "    dneff_dwl = (ng - neff) / wl0\n",
+    "    neff = neff - dwl * dneff_dwl\n",
+    "    phase = 2 * jnp.pi * neff * length / wl\n",
+    "    transmission = 10 ** (-loss * length / 20) * jnp.exp(1j * phase)\n",
+    "    return sax.reciprocal(\n",
+    "        {\n",
+    "            (\"in0\", \"out0\"): transmission,\n",
+    "        }\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## MZI Circuit\n",
+    "\n",
+    "Now let's create a Mach-Zehnder Interferometer (MZI) circuit:\n",
+    "\n",
+    "```\n",
+    "        _________\n",
+    "       |   top   |\n",
+    "in0 ---+---------+--- out0\n",
+    "       |         |\n",
+    "in1 ---+---------+--- out1\n",
+    "       |___btm___|\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mzi_netlist = {\n",
+    "    \"instances\": {\n",
+    "        \"lft\": \"coupler\",\n",
+    "        \"top\": \"waveguide\",\n",
+    "        \"btm\": \"waveguide\",\n",
+    "        \"rgt\": \"coupler\",\n",
+    "    },\n",
+    "    \"connections\": {\n",
+    "        \"lft,out0\": \"btm,in0\",\n",
+    "        \"btm,out0\": \"rgt,in0\",\n",
+    "        \"lft,out1\": \"top,in0\",\n",
+    "        \"top,out0\": \"rgt,in1\",\n",
+    "    },\n",
+    "    \"ports\": {\n",
+    "        \"in0\": \"lft,in0\",\n",
+    "        \"in1\": \"lft,in1\",\n",
+    "        \"out0\": \"rgt,out0\",\n",
+    "        \"out1\": \"rgt,out1\",\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "models = {\n",
+    "    \"coupler\": coupler,\n",
+    "    \"waveguide\": waveguide,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Adding Probes\n",
+    "\n",
+    "To observe the signal at intermediate points, we can add probes using the `probes` argument to `sax.circuit()`. Each probe is specified as a mapping from probe name to instance port.\n",
+    "\n",
+    "Let's add probes to measure the signal in both arms of the MZI:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mzi_with_probes, info = sax.circuit(\n",
+    "    netlist=mzi_netlist,\n",
+    "    models=models,\n",
+    "    probes={\n",
+    "        \"top_arm\": \"top,in0\",  # Probe at the input of the top waveguide\n",
+    "        \"btm_arm\": \"btm,in0\",  # Probe at the input of the bottom waveguide\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "The circuit now has additional ports for each probe. Each probe creates two ports:\n",
+    "- `{name}_fwd`: Signal flowing **into** the probed port\n",
+    "- `{name}_bwd`: Signal flowing **out of** the probed port"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "S = mzi_with_probes()\n",
+    "ports = sax.get_ports(S)\n",
+    "print(\"Circuit ports:\", ports)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Simulating with Probes\n",
+    "\n",
+    "Let's simulate the MZI with different arm lengths and observe the signal at the probe points:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wl = jnp.linspace(1.5, 1.6, 1000)\n",
+    "\n",
+    "S = mzi_with_probes(\n",
+    "    wl=wl,\n",
+    "    top={\"length\": 25.0},\n",
+    "    btm={\"length\": 15.0},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### Output Transmission\n",
+    "\n",
+    "First, let's look at the standard output transmission:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"out0\"]) ** 2, label=\"in0 → out0\")\n",
+    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"out1\"]) ** 2, label=\"in0 → out1\")\n",
+    "plt.xlabel(\"Wavelength [nm]\")\n",
+    "plt.ylabel(\"Transmission\")\n",
+    "plt.title(\"MZI Output Transmission\")\n",
+    "plt.legend()\n",
+    "plt.ylim(-0.05, 1.05)\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "### Signal at Probe Points\n",
+    "\n",
+    "Now let's look at the signal entering each arm of the MZI. The `_fwd` ports show us the signal flowing into the probed ports:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"top_arm_fwd\"]) ** 2, label=\"in0 → top arm (fwd)\")\n",
+    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"btm_arm_fwd\"]) ** 2, label=\"in0 → btm arm (fwd)\")\n",
+    "plt.xlabel(\"Wavelength [nm]\")\n",
+    "plt.ylabel(\"Power\")\n",
+    "plt.title(\"Signal Entering Each Arm (from in0)\")\n",
+    "plt.legend()\n",
+    "plt.ylim(-0.05, 1.05)\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "As expected with a 50/50 coupler, the signal is split equally between the two arms.\n",
+    "\n",
+    "We can also look at the backward-traveling signal (reflections coming back from the right coupler):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"top_arm_bwd\"]) ** 2, label=\"in0 → top arm (bwd)\")\n",
+    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"btm_arm_bwd\"]) ** 2, label=\"in0 → btm arm (bwd)\")\n",
+    "plt.xlabel(\"Wavelength [nm]\")\n",
+    "plt.ylabel(\"Power\")\n",
+    "plt.title(\"Backward Signal at Each Arm (from in0)\")\n",
+    "plt.legend()\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "The backward-traveling signal shows the interference pattern! This is because:\n",
+    "1. Light enters from `in0` and splits at the left coupler\n",
+    "2. It travels through both arms with different phases (due to different lengths)\n",
+    "3. At the right coupler, some light reflects back into each arm\n",
+    "4. The backward signal shows this reflected, interfered light"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "## Comparing Forward and Backward Signals\n",
+    "\n",
+    "Let's compare the forward and backward signals at one probe point:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(\n",
+    "    wl * 1e3, jnp.abs(S[\"in0\", \"top_arm_fwd\"]) ** 2, label=\"Forward (into top arm)\"\n",
+    ")\n",
+    "plt.plot(\n",
+    "    wl * 1e3, jnp.abs(S[\"in0\", \"top_arm_bwd\"]) ** 2, label=\"Backward (out of top arm)\"\n",
+    ")\n",
+    "plt.xlabel(\"Wavelength [nm]\")\n",
+    "plt.ylabel(\"Power\")\n",
+    "plt.title(\"Forward vs Backward Signal at Top Arm Probe\")\n",
+    "plt.legend()\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "## Phase Information\n",
+    "\n",
+    "Probes also give us access to phase information, which is crucial for understanding interference:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(wl * 1e3, jnp.angle(S[\"in0\", \"top_arm_fwd\"]), label=\"Top arm phase\")\n",
+    "plt.plot(wl * 1e3, jnp.angle(S[\"in0\", \"btm_arm_fwd\"]), label=\"Bottom arm phase\")\n",
+    "plt.xlabel(\"Wavelength [nm]\")\n",
+    "plt.ylabel(\"Phase [rad]\")\n",
+    "plt.title(\"Phase of Signal Entering Each Arm\")\n",
+    "plt.legend()\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
+   "source": [
+    "The phase difference between the arms determines the interference at the output. Let's compute it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phase_top = jnp.angle(S[\"in0\", \"top_arm_fwd\"])\n",
+    "phase_btm = jnp.angle(S[\"in0\", \"btm_arm_fwd\"])\n",
+    "phase_diff = jnp.unwrap(phase_top - phase_btm)\n",
+    "\n",
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(wl * 1e3, phase_diff / jnp.pi, label=\"Phase difference\")\n",
+    "plt.xlabel(\"Wavelength [nm]\")\n",
+    "plt.ylabel(\"Phase difference [π rad]\")\n",
+    "plt.title(\"Phase Difference Between Arms\")\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27",
+   "metadata": {},
+   "source": [
+    "## Probes Don't Affect Circuit Behavior\n",
+    "\n",
+    "An important property of probes is that they don't affect the circuit's behavior. Let's verify this by comparing with a circuit without probes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Circuit without probes\n",
+    "mzi_no_probes, _ = sax.circuit(netlist=mzi_netlist, models=models)\n",
+    "\n",
+    "S_no_probes = mzi_no_probes(wl=wl, top={\"length\": 25.0}, btm={\"length\": 15.0})\n",
+    "\n",
+    "# Compare outputs\n",
+    "diff = jnp.abs(S[\"in0\", \"out0\"] - S_no_probes[\"in0\", \"out0\"])\n",
+    "print(f\"Maximum difference in transmission: {jnp.max(diff):.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "The outputs are identical (within numerical precision), confirming that probes are purely observational."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The `probes` feature in SAX allows you to:\n",
+    "\n",
+    "1. **Observe intermediate signals** without modifying your netlist\n",
+    "2. **Debug circuit behavior** by seeing what happens inside\n",
+    "3. **Analyze both forward and backward propagating waves** at any connection point\n",
+    "4. **Access phase information** for understanding interference\n",
+    "\n",
+    "Key points:\n",
+    "- Probes are specified as `probes={\"name\": \"instance,port\"}` in `sax.circuit()`\n",
+    "- Each probe creates `{name}_fwd` and `{name}_bwd` ports\n",
+    "- `_fwd` captures signal flowing **into** the specified port\n",
+    "- `_bwd` captures signal flowing **out of** the specified port\n",
+    "- Probes are unphysical (they don't conserve energy) but don't affect circuit behavior"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/examples/14_probes.ipynb
+++ b/nbs/examples/14_probes.ipynb
@@ -282,132 +282,12 @@
    "id": "18",
    "metadata": {},
    "source": [
-    "As expected with a 50/50 coupler, the signal is split equally between the two arms.\n",
-    "\n",
-    "We can also look at the backward-traveling signal (reflections coming back from the right coupler):"
+    "As expected with a 50/50 coupler, the signal is split equally between the two arms.\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "19",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize=(10, 4))\n",
-    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"top_arm_bwd\"]) ** 2, label=\"in0 → top arm (bwd)\")\n",
-    "plt.plot(wl * 1e3, jnp.abs(S[\"in0\", \"btm_arm_bwd\"]) ** 2, label=\"in0 → btm arm (bwd)\")\n",
-    "plt.xlabel(\"Wavelength [nm]\")\n",
-    "plt.ylabel(\"Power\")\n",
-    "plt.title(\"Backward Signal at Each Arm (from in0)\")\n",
-    "plt.legend()\n",
-    "plt.grid(True, alpha=0.3)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "20",
-   "metadata": {},
-   "source": [
-    "The backward-traveling signal shows the interference pattern! This is because:\n",
-    "1. Light enters from `in0` and splits at the left coupler\n",
-    "2. It travels through both arms with different phases (due to different lengths)\n",
-    "3. At the right coupler, some light reflects back into each arm\n",
-    "4. The backward signal shows this reflected, interfered light"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "21",
-   "metadata": {},
-   "source": [
-    "## Comparing Forward and Backward Signals\n",
-    "\n",
-    "Let's compare the forward and backward signals at one probe point:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize=(10, 4))\n",
-    "plt.plot(\n",
-    "    wl * 1e3, jnp.abs(S[\"in0\", \"top_arm_fwd\"]) ** 2, label=\"Forward (into top arm)\"\n",
-    ")\n",
-    "plt.plot(\n",
-    "    wl * 1e3, jnp.abs(S[\"in0\", \"top_arm_bwd\"]) ** 2, label=\"Backward (out of top arm)\"\n",
-    ")\n",
-    "plt.xlabel(\"Wavelength [nm]\")\n",
-    "plt.ylabel(\"Power\")\n",
-    "plt.title(\"Forward vs Backward Signal at Top Arm Probe\")\n",
-    "plt.legend()\n",
-    "plt.grid(True, alpha=0.3)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "23",
-   "metadata": {},
-   "source": [
-    "## Phase Information\n",
-    "\n",
-    "Probes also give us access to phase information, which is crucial for understanding interference:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "24",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize=(10, 4))\n",
-    "plt.plot(wl * 1e3, jnp.angle(S[\"in0\", \"top_arm_fwd\"]), label=\"Top arm phase\")\n",
-    "plt.plot(wl * 1e3, jnp.angle(S[\"in0\", \"btm_arm_fwd\"]), label=\"Bottom arm phase\")\n",
-    "plt.xlabel(\"Wavelength [nm]\")\n",
-    "plt.ylabel(\"Phase [rad]\")\n",
-    "plt.title(\"Phase of Signal Entering Each Arm\")\n",
-    "plt.legend()\n",
-    "plt.grid(True, alpha=0.3)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "25",
-   "metadata": {},
-   "source": [
-    "The phase difference between the arms determines the interference at the output. Let's compute it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "26",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "phase_top = jnp.angle(S[\"in0\", \"top_arm_fwd\"])\n",
-    "phase_btm = jnp.angle(S[\"in0\", \"btm_arm_fwd\"])\n",
-    "phase_diff = jnp.unwrap(phase_top - phase_btm)\n",
-    "\n",
-    "plt.figure(figsize=(10, 4))\n",
-    "plt.plot(wl * 1e3, phase_diff / jnp.pi, label=\"Phase difference\")\n",
-    "plt.xlabel(\"Wavelength [nm]\")\n",
-    "plt.ylabel(\"Phase difference [π rad]\")\n",
-    "plt.title(\"Phase Difference Between Arms\")\n",
-    "plt.grid(True, alpha=0.3)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "27",
    "metadata": {},
    "source": [
     "## Probes Don't Affect Circuit Behavior\n",
@@ -418,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "21",
    "metadata": {},
    "source": [
     "The outputs are identical (within numerical precision), confirming that probes are purely observational."
@@ -442,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -465,9 +345,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "sax",
    "language": "python",
-   "name": "python3"
+   "name": "sax"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/sax/models/__init__.py
+++ b/src/sax/models/__init__.py
@@ -28,6 +28,9 @@ from .mmis import (
     mmi2x2,
     mmi2x2_ideal,
 )
+from .probes import (
+    ideal_probe,
+)
 from .splitters import (
     splitter_ideal,
 )
@@ -45,6 +48,7 @@ __all__ = [
     "coupler_ideal",
     "crossing_ideal",
     "grating_coupler",
+    "ideal_probe",
     "mmi1x2",
     "mmi1x2_ideal",
     "mmi2x2",

--- a/src/sax/models/probes.py
+++ b/src/sax/models/probes.py
@@ -1,0 +1,82 @@
+"""SAX Probe Models."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from pydantic import validate_call
+
+import sax
+
+__all__ = ["ideal_probe"]
+
+
+@validate_call
+def ideal_probe(wl: sax.FloatArrayLike = sax.WL_C) -> sax.SDict:
+    """Ideal 4-port measurement probe with 100% transmission and 100% tap coupling.
+
+    This is an unphysical component designed for debugging and measurement purposes.
+    It intercepts a connection and provides access to both forward and backward
+    traveling waves without affecting the signal propagation.
+
+    ```
+              in ─────────────────── out
+               │                     │
+               │     (ideal tap)     │
+               │                     │
+             tap_bwd               tap_fwd
+    ```
+
+    The probe has the following behavior:
+    - Full transmission from `in` to `out` (and vice versa)
+    - Forward tap (`tap_fwd`) copies the signal traveling from `in` toward `out`
+    - Backward tap (`tap_bwd`) copies the signal traveling from `out` toward `in`
+    - No reflections at any port
+    - No cross-coupling between tap ports
+
+    Note:
+        This S-matrix is NOT unitary (violates energy conservation). This is
+        intentional—it's a measurement tool, not a physical device.
+
+    Args:
+        wl: Wavelength in micrometers. Defaults to 1.55 μm.
+
+    Returns:
+        S-parameter dictionary for the ideal probe.
+
+    Example:
+        Probes are typically not used directly, but via the `probes` argument
+        to `sax.circuit()`:
+
+        ```python
+        circuit_fn, info = sax.circuit(
+            netlist,
+            models=models,
+            probes={"mid": "wg1,out"},
+        )
+        # Circuit now has additional ports: mid_fwd, mid_bwd
+        ```
+    """
+    one = jnp.ones_like(jnp.asarray(wl))
+    zero = jnp.zeros_like(jnp.asarray(wl))
+    return {
+        # Through path: full transmission
+        ("in", "out"): one,
+        ("out", "in"): one,
+        # Forward tap: copies signal from in→out direction
+        ("in", "tap_fwd"): one,
+        ("tap_fwd", "in"): one,
+        # Backward tap: copies signal from out→in direction
+        ("out", "tap_bwd"): one,
+        ("tap_bwd", "out"): one,
+        # No cross-coupling between taps
+        ("tap_fwd", "tap_bwd"): zero,
+        ("tap_bwd", "tap_fwd"): zero,
+        # No coupling from taps to opposite main port
+        ("tap_fwd", "out"): zero,
+        ("tap_bwd", "in"): zero,
+        # No reflections
+        ("in", "in"): zero,
+        ("out", "out"): zero,
+        ("tap_fwd", "tap_fwd"): zero,
+        ("tap_bwd", "tap_bwd"): zero,
+    }

--- a/src/tests/test_probes.py
+++ b/src/tests/test_probes.py
@@ -1,0 +1,450 @@
+"""Tests for the probes feature."""
+
+import pytest
+
+import sax
+
+
+def test_ideal_probe_model() -> None:
+    """Test that the ideal_probe model returns the expected S-matrix."""
+    s = sax.models.ideal_probe(wl=1.55)
+
+    # Check all expected ports exist
+    expected_ports = {"in", "out", "tap_fwd", "tap_bwd"}
+    ports = sax.get_ports(s)
+    assert set(ports) == expected_ports
+
+    # Check through path has full transmission
+    assert float(s[("in", "out")]) == 1.0
+    assert float(s[("out", "in")]) == 1.0
+
+    # Check tap coupling
+    assert float(s[("in", "tap_fwd")]) == 1.0
+    assert float(s[("tap_fwd", "in")]) == 1.0
+    assert float(s[("out", "tap_bwd")]) == 1.0
+    assert float(s[("tap_bwd", "out")]) == 1.0
+
+    # Check no cross-coupling between taps
+    assert float(s[("tap_fwd", "tap_bwd")]) == 0.0
+    assert float(s[("tap_bwd", "tap_fwd")]) == 0.0
+
+    # Check no reflections
+    assert float(s[("in", "in")]) == 0.0
+    assert float(s[("out", "out")]) == 0.0
+    assert float(s[("tap_fwd", "tap_fwd")]) == 0.0
+    assert float(s[("tap_bwd", "tap_bwd")]) == 0.0
+
+
+def test_basic_probe_insertion() -> None:
+    """Test basic probe insertion on a simple 2-waveguide circuit."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    # Without probes
+    circuit_no_probe, _ = sax.circuit(netlist, models)
+    result_no_probe = circuit_no_probe()
+    ports_no_probe = sax.get_ports(result_no_probe)
+    assert set(ports_no_probe) == {"in", "out"}
+
+    # With probe
+    circuit_with_probe, _ = sax.circuit(
+        netlist,
+        models,
+        probes={"mid": "wg1,out0"},
+    )
+    result_with_probe = circuit_with_probe()
+    ports_with_probe = sax.get_ports(result_with_probe)
+    assert set(ports_with_probe) == {"in", "out", "mid_fwd", "mid_bwd"}
+
+
+def test_probe_on_right_side_of_connection() -> None:
+    """Test that probes work when specified on the right side of a connection."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    # Probe on right side of connection (wg2,in0 instead of wg1,out0)
+    circuit_fn, _ = sax.circuit(
+        netlist,
+        models,
+        probes={"mid": "wg2,in0"},
+    )
+    result = circuit_fn()
+    ports = sax.get_ports(result)
+    assert set(ports) == {"in", "out", "mid_fwd", "mid_bwd"}
+
+
+def test_probe_fwd_direction_left_side() -> None:
+    """Test _fwd captures signal flowing INTO user-specified port (left side)."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    # Probe at wg1,out0 (left side of connection)
+    # _fwd should capture signal flowing INTO wg1,out0 (i.e., from wg2 back to wg1)
+    # _bwd should capture signal flowing OUT of wg1,out0 (i.e., from wg1 to wg2)
+    circuit_fn, _ = sax.circuit(
+        netlist,
+        models,
+        probes={"mid": "wg1,out0"},
+    )
+    result = circuit_fn()
+
+    # Signal from "in" goes through wg1 and exits at wg1,out0
+    # This should appear at mid_bwd (signal flowing OUT of the probed port)
+    assert ("in", "mid_bwd") in result
+
+    # Signal from "out" goes back through wg2 and into wg1,out0
+    # This should appear at mid_fwd (signal flowing INTO the probed port)
+    assert ("out", "mid_fwd") in result
+
+
+def test_probe_fwd_direction_right_side() -> None:
+    """Test _fwd captures signal flowing INTO user-specified port (right side)."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    # Probe at wg2,in0 (right side of connection)
+    # _fwd should capture signal flowing INTO wg2,in0 (i.e., from wg1 to wg2)
+    # _bwd should capture signal flowing OUT of wg2,in0 (i.e., from wg2 back to wg1)
+    circuit_fn, _ = sax.circuit(
+        netlist,
+        models,
+        probes={"mid": "wg2,in0"},
+    )
+    result = circuit_fn()
+
+    # Signal from "in" goes through wg1 and into wg2,in0
+    # This should appear at mid_fwd (signal flowing INTO the probed port)
+    assert ("in", "mid_fwd") in result
+
+    # Signal from "out" goes back through wg2 and exits at wg2,in0
+    # This should appear at mid_bwd (signal flowing OUT of the probed port)
+    assert ("out", "mid_bwd") in result
+
+
+def test_multiple_probes() -> None:
+    """Test multiple probes on different connections."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+            "wg3": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+            "wg2,out0": "wg3,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg3,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    circuit_fn, _ = sax.circuit(
+        netlist,
+        models,
+        probes={
+            "probe1": "wg1,out0",
+            "probe2": "wg2,out0",
+        },
+    )
+    result = circuit_fn()
+    ports = sax.get_ports(result)
+    expected_ports = {
+        "in",
+        "out",
+        "probe1_fwd",
+        "probe1_bwd",
+        "probe2_fwd",
+        "probe2_bwd",
+    }
+    assert set(ports) == expected_ports
+
+
+def test_probe_in_mzi_circuit() -> None:
+    """Test probe in a more complex MZI circuit."""
+    netlist = {
+        "instances": {
+            "lft": "coupler",
+            "top": "waveguide",
+            "btm": "waveguide",
+            "rgt": "coupler",
+        },
+        "connections": {
+            "lft,out0": "btm,in0",
+            "btm,out0": "rgt,in0",
+            "lft,out1": "top,in0",
+            "top,out0": "rgt,in1",
+        },
+        "ports": {
+            "in0": "lft,in0",
+            "in1": "lft,in1",
+            "out0": "rgt,out0",
+            "out1": "rgt,out1",
+        },
+    }
+
+    models = {
+        "coupler": sax.models.coupler_ideal,
+        "waveguide": sax.models.straight,
+    }
+
+    # Probe on top arm
+    circuit_fn, _ = sax.circuit(
+        netlist,
+        models,
+        probes={"top_arm": "top,in0"},
+    )
+    result = circuit_fn()
+    ports = sax.get_ports(result)
+    expected_ports = {"in0", "in1", "out0", "out1", "top_arm_fwd", "top_arm_bwd"}
+    assert set(ports) == expected_ports
+
+
+def test_probe_values_match_transmission() -> None:
+    """Test that probe values match expected transmission through the circuit."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    circuit_fn, _ = sax.circuit(
+        netlist,
+        models,
+        probes={"mid": "wg1,out0"},
+    )
+
+    # Evaluate at a specific wavelength
+    result = circuit_fn(wl=1.55)
+
+    # The forward probe should capture signal going from wg1 to wg2
+    # The transmission in->out should still work
+    assert ("in", "out") in result
+    assert ("in", "mid_fwd") in result
+    assert ("out", "mid_bwd") in result
+
+
+def test_probe_error_on_non_connected_port() -> None:
+    """Test that probes raise error when referencing non-connected ports."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+        },
+        "connections": {},
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg1,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    with pytest.raises(ValueError, match="not part of any connection"):
+        sax.circuit(
+            netlist,
+            models,
+            probes={"mid": "wg1,out0"},
+        )
+
+
+def test_probe_error_on_port_conflict() -> None:
+    """Test that probes raise error when port names would conflict."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+            "mid_fwd": "wg2,out0",  # Conflict with probe port
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    with pytest.raises(ValueError, match="conflict with existing ports"):
+        sax.circuit(
+            netlist,
+            models,
+            probes={"mid": "wg1,out0"},
+        )
+
+
+def test_probe_error_on_instance_conflict() -> None:
+    """Test that probes raise error when instance name would conflict."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+            "_probe_mid": "waveguide",  # Conflict with probe instance name
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    with pytest.raises(ValueError, match="conflicts with an existing instance"):
+        sax.circuit(
+            netlist,
+            models,
+            probes={"mid": "wg1,out0"},
+        )
+
+
+def test_empty_probes_dict() -> None:
+    """Test that empty probes dict is a no-op."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    circuit_fn, _ = sax.circuit(netlist, models, probes={})
+    result = circuit_fn()
+    ports = sax.get_ports(result)
+    assert set(ports) == {"in", "out"}
+
+
+def test_probe_with_none() -> None:
+    """Test that probes=None is a no-op."""
+    netlist = {
+        "instances": {
+            "wg1": "waveguide",
+            "wg2": "waveguide",
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    models = {
+        "waveguide": sax.models.straight,
+    }
+
+    circuit_fn, _ = sax.circuit(netlist, models, probes=None)
+    result = circuit_fn()
+    ports = sax.get_ports(result)
+    assert set(ports) == {"in", "out"}
+
+
+if __name__ == "__main__":
+    test_ideal_probe_model()
+    test_basic_probe_insertion()
+    test_probe_on_right_side_of_connection()
+    test_multiple_probes()
+    test_probe_in_mzi_circuit()
+    test_probe_values_match_transmission()
+    test_probe_error_on_non_connected_port()
+    test_probe_error_on_port_conflict()
+    test_probe_error_on_instance_conflict()
+    test_empty_probes_dict()
+    test_probe_with_none()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

- Add a `probes` parameter to `sax.circuit()` that allows inserting ideal 4-port measurement probes at connection points
- Each probe intercepts a connection and exposes forward (`_fwd`) and backward (`_bwd`) traveling wave ports
- Probes are unphysical (100% transmission AND 100% tap coupling) but useful for debugging and measuring intermediate signals
- Netlist schema remains unchanged, preserving GDSFactory compatibility

## Example Usage

```python
netlist = {
    "instances": {"wg1": "waveguide", "wg2": "waveguide"},
    "connections": {"wg1,out": "wg2,in"},
    "ports": {"in": "wg1,in", "out": "wg2,out"},
}

circuit_fn, info = sax.circuit(
    netlist,
    models=models,
    probes={"mid": "wg1,out"},  # Probe at the connection point
)

# Circuit now has ports: in, out, mid_fwd, mid_bwd
result = circuit_fn(wl=1.55)
```

## Changes

- `src/sax/models/probes.py`: New `ideal_probe()` model (4-port measurement tap)
- `src/sax/netlists.py`: Add `expand_probes()` function to transform probes into instances
- `src/sax/circuits.py`: Add `probes` parameter to `circuit()` function
- `src/tests/test_probes.py`: Comprehensive test coverage

## Test plan

- [x] Test ideal_probe model returns correct S-matrix
- [x] Test basic probe insertion on 2-waveguide circuit
- [x] Test probe on either side of connection
- [x] Test multiple probes on different connections
- [x] Test probe in complex MZI circuit
- [x] Test error handling for invalid probe configurations
- [x] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)