### PR TITLE
Refactor development dependencies into logical groups

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 dev: bver
   uv venv --python 3.12 --clear
-  uv sync --all-extras
+  uv sync --dev
   uv pip install -e .
   uv run pre-commit install
 
@@ -25,10 +25,10 @@ uv:
   curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ipykernel:
-  uv run --extra dev python -m ipykernel install --user --name sax --display-name sax
+  uv run --dev python -m ipykernel install --user --name sax --display-name sax
 
 test: ipykernel
-  uv run --extra dev pytest -s -n logical
+  uv run --dev pytest -s -n logical
 
 docs:
   sed 's|](docs/|](|g' README.md > docs/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,53 @@
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=61", "uv", "build", "wheel"]
 
+[dependency-groups]
+dev = [
+  {include-group = "docs"},
+  {include-group = "lint"},
+  {include-group = "test"},
+  "build>=1.2.0",
+  "gdsfactory>=9.34.1",
+  "meow-sim>=0.14.0",
+  "mkinit>=1.1.0",
+  "optax>=0.2.0",
+  "scikit-learn>=1.6.1",
+  "tmm>=0.2.0",
+  "towncrier>=24.0.0",
+  "ty>=0.0.1a11"
+]
+docs = [
+  "altair>=5.5.0",
+  "griffe>=1.5.6",
+  "ipykernel>=6.29.5",
+  "matplotlib>=3.10.0",
+  "mkautodoc>=0.2.0",
+  "mkdocs-autorefs>=1.3.0",
+  "mkdocs-bibtex>=4.4.0",
+  "mkdocs-material>=9.6.0",
+  "mkdocs-matplotlib",
+  "mkdocs>=1.6.1",
+  "mkdocstrings[python]>=0.27.0",
+  "nbconvert>=7.16.6",
+  "plotly>=6.0.0",
+  "pydot>=4.0.1",
+  "vega-datasets>=0.9.0"
+]
+lint = [
+  "nb-clean>=4.0.1",
+  "nbstripout>=0.8.1",
+  "pre-commit>=4.1.0",
+  "pyright>=1.1.0",
+  "ruff>=0.9.0"
+]
+test = [
+  "papermill>=2.6.0",
+  "pytest-cov>=6.0.0",
+  "pytest-randomly>=3.16.0",
+  "pytest-xdist>=3.6.0",
+  "pytest>=8.3.0"
+]
+
 [project]
 authors = [{name = "Floris Laporte", email = "floris.laporte@gmail.com"}]
 classifiers = [
@@ -54,45 +101,6 @@ name = "sax"
 readme = "README.md"
 requires-python = ">=3.11.0"
 version = "0.16.5"
-
-[project.optional-dependencies]
-dev = [
-  "altair>=5.5.0",
-  "optax>=0.2.0",
-  "build>=1.2.0",
-  "gdsfactory>=9.34.1",
-  "griffe>=1.5.6",
-  "ipykernel>=6.29.5",
-  "matplotlib>=3.10.0",
-  "meow-sim>=0.14.0",
-  "mkautodoc>=0.2.0",
-  "mkdocs-autorefs>=1.3.0",
-  "mkdocs-bibtex>=4.4.0",
-  "mkdocs-material>=9.6.0",
-  "mkdocs>=1.6.1",
-  "mkdocstrings[python]>=0.27.0",
-  "mkinit>=1.1.0",
-  "nbconvert>=7.16.6",
-  "papermill>=2.6.0",
-  "plotly>=6.0.0",
-  "pre-commit>=4.1.0",
-  "pyright>=1.1.0",
-  "pytest-cov>=6.0.0",
-  "pytest-randomly>=3.16.0",
-  "pytest-xdist>=3.6.0",
-  "pytest>=8.3.0",
-  "ruff>=0.9.0",
-  "scikit-learn>=1.6.1",
-  "tmm>=0.2.0",
-  "towncrier>=24.0.0",
-  "vega-datasets>=0.9.0",
-  "nb-clean>=4.0.1",
-  "ty>=0.0.1a11",
-  "nbstripout>=0.8.1",
-  "mkdocs-matplotlib",
-  "scikit-rf>=1.8.0",
-  "pydot>=4.0.1"
-]
 
 [[tool.bver.file]]
 kind = "python"


### PR DESCRIPTION
Refactored the dev extra to dependency groups for local development in pyproject.toml. Updated the justfile to use the new dependency group structure with `uv sync --dev` and `uv run --dev`.

Closes #86 