### PR TITLE
Add RF waveguide models for CPW and Microstrips

### DIFF
--- a/docs/models_rf.md
+++ b/docs/models_rf.md
@@ -2,4 +2,22 @@
 
 For more information on these RF models, see Ref. [@pozar-2012].
 
+## Coplanar Waveguides (CPW) and Microstrips
+
+Sax includes JAX-jittable functions for computing the characteristic impedance, effective permittivity, and propagation constant of coplanar waveguides and microstrip lines. All results are obtained analytically so the functions compose freely with JAX transformations (`jit`, `grad`, `vmap`, etc.).
+
+### CPW Theory
+
+The quasi-static CPW analysis follows the conformal-mapping approach described by Simons [@simonsCoplanarWaveguideCircuits2001] (ch. 2) and Ghione & Naldi [@ghioneAnalyticalFormulasCoplanar1984]. Conductor thickness corrections use the first-order formulae of Gupta, Garg, Bahl & Bhartia [@guptaMicrostripLinesSlotlines1996] (§7.3, Eqs. 7.98-7.100).
+
+### Microstrip Theory
+
+The microstrip analysis uses the Hammerstad-Jensen [@hammerstadAccurateModelsMicrostrip1980] closed-form expressions for effective permittivity and characteristic impedance, as presented in Pozar [@pozar-2012] (ch. 3, §3.8).
+
+### General
+
+The ABCD-to-S-parameter conversion is the standard microwave-network relation from Pozar [@pozar-2012] (ch. 4).
+
+The implementation was cross-checked against the Qucs-S model (see Qucs technical documentation [@qucs_technical_papers], §12 for CPW, §11 for microstrip) and the `scikit-rf` CPW class.
+
 ::: sax.models.rf

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -33,3 +33,62 @@
     publisher={John Wiley \& Sons, Inc.},
     isbn={978-0-470-63155-3}
 }
+
+@article{ghioneAnalyticalFormulasCoplanar1984,
+  title = {Analytical Formulas for Coplanar Lines in Hybrid and Monolithic {{MICs}}},
+  author = {Ghione, G. and Naldi, C.},
+  year = {1984},
+  month = feb,
+  journal = {Electronics Letters},
+  volume = {20},
+  number = {4},
+  pages = {179--181},
+  publisher = {The Institution of Engineering and Technology},
+  doi = {10.1049/el:19840120},
+  abstract = {Some analytical formulas for the parameters of coplanar lines are discussed and validated; a chart is given for the design of coplanar waveguides on GaAs. The formulas discussed here, together with those presented previously by us (1983) represent a suitable set for the design of coplanar lines for hybrid and monolithic MICs (microwave integrated circuits).}
+}
+
+@book{guptaMicrostripLinesSlotlines1996,
+  title = {Microstrip Lines and Slotlines},
+  author = {Gupta, Kuldip C. and Garg, R. and Bahl, I. and Bhartia, P.},
+  year = {1996},
+  edition = {2. ed},
+  publisher = {Artech House},
+  address = {Boston},
+  isbn = {978-0-89006-766-6},
+  langid = {english}
+}
+
+@inproceedings{hammerstadAccurateModelsMicrostrip1980,
+  title = {Accurate {{Models}} for {{Microstrip Computer-Aided Design}}},
+  booktitle = {1980 {{IEEE MTT-S International Microwave}} Symposium {{Digest}}},
+  author = {Hammerstad, E. and Jensen, O.},
+  year = {1980},
+  pages = {407--409},
+  publisher = {IEEE},
+  address = {Washington, DC, USA},
+  doi = {10.1109/MWSYM.1980.1124303}
+}
+
+@book{simonsCoplanarWaveguideCircuits2001,
+  title = {Coplanar Waveguide Circuits, Components, and Systems},
+  author = {Simons, Rainee},
+  year = {2001},
+  series = {Wiley {{Series}} in {{Microwave}} and {{Optical Engineering}}},
+  number = {v. 165},
+  publisher = {Wiley Interscience},
+  address = {New York},
+  doi = {10.1002/0471224758},
+  isbn = {978-0-471-22475-4 978-0-471-46393-1},
+  langid = {english}
+}
+
+@manual{qucs_technical_papers,
+  title        = {Qucs Technical Papers},
+  author       = {Stefan Jahn and Michael Margraf and Vincent Habchi and Raimund Jacob},
+  organization = {Qucs (Quite Universal Circuit Simulator) Project},
+  year         = {2007},
+  month        = dec,
+  url          = {https://qucs.sourceforge.net/docs/technical/technical.pdf},
+  urldate      = {2026-03-13}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ lint = [
   "ruff>=0.9.0"
 ]
 test = [
+  "hypothesis>=6.0.0",
+  "jaxellip>=0.0.1",
   "papermill>=2.6.0",
   "pytest-cov>=6.0.0",
   "pytest-randomly>=3.16.0",
@@ -102,6 +104,9 @@ name = "sax"
 readme = "README.md"
 requires-python = ">=3.11.0"
 version = "0.16.13"
+
+[project.optional-dependencies]
+rf = ["jaxellip>=0.0.1"]
 
 [[tool.bver.file]]
 kind = "python"

--- a/src/sax/constants.py
+++ b/src/sax/constants.py
@@ -22,6 +22,7 @@ from sax.saxtypes.core import FloatArray1D
 __all__ = [
     "C_M_S",
     "C_UM_S",
+    "DEFAULT_FREQUENCY",
     "DEFAULT_MODE",
     "DEFAULT_MODES",
     "DEFAULT_WL_STEP",
@@ -57,6 +58,9 @@ C_M_S: float = 299792458.0
 
 C_UM_S: float = 1e6 * C_M_S
 """Speed of light in vacuum (μm/s)."""
+
+DEFAULT_FREQUENCY: float = 5e9
+"""Default radio frequency (Hz)."""
 
 DEFAULT_MODE: str = "TE"
 """Default optical mode."""

--- a/src/sax/models/rf.py
+++ b/src/sax/models/rf.py
@@ -842,7 +842,8 @@ def transmission_line_s_params(
 
     $$
     \begin{aligned}
-        S_{11} &= \frac{A + B/Z_{\mathrm{ref}} - CZ_{\mathrm{ref}} - D}{A + B/Z_{\mathrm{ref}} + CZ_{\mathrm{ref}} + D} \\
+        S_{11} &= \frac{A + B/Z_{\mathrm{ref}} - CZ_{\mathrm{ref}} - D}{
+            A + B/Z_{\mathrm{ref}} + CZ_{\mathrm{ref}} + D} \\
         S_{21} &= \frac{2}{A + B/Z_{\mathrm{ref}} + CZ_{\mathrm{ref}} + D}
     \end{aligned}
     $$
@@ -964,9 +965,9 @@ def microstrip(
 ) -> sax.SDict:
     r"""S-parameter model for a straight microstrip transmission line.
 
-    Computes S-parameters analytically using the Hammerstad-Jensen closed-form expressions
-    for effective permittivity and characteristic impedance, as described
-    in Pozar.
+    Computes S-parameters analytically using the Hammerstad-Jensen closed-form
+    expressions for effective permittivity and characteristic impedance, as
+    described in Pozar.
     Conductor thickness corrections follow
     Gupta et al.
 

--- a/src/sax/models/rf.py
+++ b/src/sax/models/rf.py
@@ -1,13 +1,27 @@
-"""Sax generic RF models."""
+r"""Sax generic RF models.
 
+This module provides generic RF components and JAX-jittable functions for
+computing the characteristic impedance, effective permittivity, and
+propagation constant of coplanar waveguides and microstrip lines.
+
+Note:
+    Some models in this module require the ``jaxellip`` package.
+    Install the ``rf`` extra to include it: ``pip install sax[rf]``.
+"""
+
+import typing
 from functools import partial
 
 import jax
 import jax.numpy as jnp
 
 import sax
+from sax.constants import C_M_S, DEFAULT_FREQUENCY
 
-DEFAULT_FREQUENCY = 5e9
+try:
+    import jaxellip  # pyright: ignore[reportMissingImports]
+except ImportError:
+    jaxellip = None
 
 
 @partial(jax.jit, inline=True, static_argnames=("n_ports"))
@@ -26,7 +40,7 @@ def gamma_0_load(
             are set to Γ₀ and the off-diagonal ports to 0.
 
     Returns:
-        sax.SType: S-parameters dictionary where :math:`S = \Gamma_0I_\text{n\_ports}`
+        sax.SType: S-parameters dictionary where $S = \Gamma_0I_\text{n_ports}$
 
     Examples:
         ```python
@@ -34,6 +48,9 @@ def gamma_0_load(
         import matplotlib.pyplot as plt
         import numpy as np
         import sax
+        import jaxellip  # pyright: ignore[reportMissingImports]
+        import scipy.constants
+
 
         sax.set_port_naming_strategy("optical")
 
@@ -88,6 +105,9 @@ def tee(*, f: sax.FloatArrayLike = DEFAULT_FREQUENCY) -> sax.SDict:
         import matplotlib.pyplot as plt
         import numpy as np
         import sax
+        import jaxellip  # pyright: ignore[reportMissingImports]
+        import scipy.constants
+
 
         sax.set_port_naming_strategy("optical")
 
@@ -131,7 +151,7 @@ def impedance(
         S-dictionary representing the impedance element
 
     References:
-        [@pozar2012]
+        Pozar
 
     Examples:
         ```python
@@ -139,6 +159,9 @@ def impedance(
         import matplotlib.pyplot as plt
         import numpy as np
         import sax
+        import jaxellip  # pyright: ignore[reportMissingImports]
+        import scipy.constants
+
 
         sax.set_port_naming_strategy("optical")
 
@@ -176,7 +199,7 @@ def admittance(
         S-dictionary representing the admittance element
 
     References:
-        [@pozar2012]
+        Pozar
 
     Examples:
         ```python
@@ -184,6 +207,9 @@ def admittance(
         import matplotlib.pyplot as plt
         import numpy as np
         import sax
+        import jaxellip  # pyright: ignore[reportMissingImports]
+        import scipy.constants
+
 
         sax.set_port_naming_strategy("optical")
 
@@ -225,7 +251,7 @@ def capacitor(
         S-dictionary representing the capacitor element
 
     References:
-        [@pozar2012]
+        Pozar
 
     Examples:
         ```python
@@ -233,6 +259,9 @@ def capacitor(
         import matplotlib.pyplot as plt
         import numpy as np
         import sax
+        import jaxellip  # pyright: ignore[reportMissingImports]
+        import scipy.constants
+
 
         sax.set_port_naming_strategy("optical")
 
@@ -270,7 +299,7 @@ def inductor(
         S-dictionary representing the inductor element
 
     References:
-        [@pozar2012]
+        Pozar
 
     Examples:
         ```python
@@ -278,6 +307,9 @@ def inductor(
         import matplotlib.pyplot as plt
         import numpy as np
         import sax
+        import jaxellip  # pyright: ignore[reportMissingImports]
+        import scipy.constants
+
 
         sax.set_port_naming_strategy("optical")
 
@@ -310,10 +342,10 @@ def electrical_short(
         n_ports: Number of ports to set as shorted
 
     Returns:
-        S-dictionary where :math:`S = -I_\text{n\_ports}`
+        S-dictionary where $S = -I_\text{n_ports}$
 
     References:
-        [@pozar2012]
+        Pozar
     """
     return gamma_0_load(f=f, gamma_0=-1, n_ports=n_ports)
 
@@ -334,10 +366,10 @@ def electrical_open(
         n_ports: Number of ports to set as opened
 
     Returns:
-        S-dictionary where :math:`S = I_\text{n\_ports}`
+        S-dictionary where $S = I_\text{n_ports}$
 
     References:
-        [@pozar2012]
+        Pozar
     """
     return gamma_0_load(f=f, gamma_0=1, n_ports=n_ports)
 
@@ -387,3 +419,593 @@ def lc_shunt_component(
     }
 
     return sax.backends.evaluate_circuit_fg((connections, ports), instances)
+
+
+@partial(jax.jit, inline=True)
+def ellipk_ratio(m: sax.FloatArrayLike) -> jax.Array:
+    """Ratio of complete elliptic integrals of the first kind K(m) / K(1-m)."""
+    if jaxellip is None:
+        msg = (
+            "jaxellip is required for RF models. Install it with `pip install sax[rf]`"
+        )
+        raise ImportError(msg)
+    m_arr = jnp.asarray(m, dtype=float)
+    return jaxellip.ellipk(m_arr) / jaxellip.ellipk(1 - m_arr)
+
+
+@partial(jax.jit, inline=True)
+def cpw_epsilon_eff(
+    w: sax.FloatArrayLike,
+    s: sax.FloatArrayLike,
+    h: sax.FloatArrayLike,
+    ep_r: sax.FloatArrayLike,
+) -> jax.Array:
+    r"""Effective permittivity of a CPW on a finite-height substrate.
+
+    $$
+    \begin{aligned}
+        k_0 &= \frac{w}{w + 2s} \\
+        k_1 &= \frac{\sinh(\pi w / 4h)}{\sinh\bigl(\pi(w + 2s) / 4h\bigr)} \\
+        q_1 &= \frac{K(k_1^2)/K(1 - k_1^2)}{K(k_0^2)/K(1 - k_0^2)}  \\
+        \varepsilon_{\mathrm{eff}} &= 1 + \frac{q_1(\varepsilon_r - 1)}{2}
+    \end{aligned}
+    $$
+
+    where $K$ is the complete elliptic integral of the first kind in
+    the *parameter* convention ($m = k^2$).
+
+    References:
+        Simoons, Eq. 2.37;
+        Ghione & Naldi
+
+    Args:
+        w: Centre-conductor width (m).
+        s: Gap to ground plane (m).
+        h: Substrate height (m).
+        ep_r: Relative permittivity of the substrate.
+
+    Returns:
+        Effective permittivity (dimensionless).
+    """
+    w = jnp.asarray(w, dtype=float)
+    s = jnp.asarray(s, dtype=float)
+    h = jnp.asarray(h, dtype=float)
+    ep_r = jnp.asarray(ep_r, dtype=float)
+    k0 = w / (w + 2.0 * s)
+    k1 = jnp.sinh(jnp.pi * w / (4.0 * h)) / jnp.sinh(jnp.pi * (w + 2.0 * s) / (4.0 * h))
+    q1 = ellipk_ratio(k1**2) / ellipk_ratio(k0**2)
+    return 1.0 + q1 * (ep_r - 1.0) / 2.0
+
+
+@partial(jax.jit, inline=True)
+def cpw_z0(
+    w: sax.FloatArrayLike,
+    s: sax.FloatArrayLike,
+    ep_eff: sax.FloatArrayLike,
+) -> jax.Array:
+    r"""Characteristic impedance of a CPW.
+
+    $$
+    Z_0 = \frac{30\pi}{\sqrt{\varepsilon_{\mathrm{eff}}} K(k_0^2)/K(1 - k_0^2)}
+    $$
+
+
+    References:
+        Simons, Eq. 2.38.
+        Note that our $w$ and $s$ correspond to Simons' $s$ and $w$.
+
+    Args:
+        w: Centre-conductor width (m).
+        s: Gap to ground plane (m).
+        ep_eff: Effective permittivity (see :func:`cpw_epsilon_eff`).
+
+    Returns:
+        Characteristic impedance (Ω).
+    """
+    w = jnp.asarray(w, dtype=float)
+    s = jnp.asarray(s, dtype=float)
+    ep_eff = jnp.asarray(ep_eff, dtype=float)
+    k0 = w / (w + 2.0 * s)
+    return 30.0 * jnp.pi / (jnp.sqrt(ep_eff) * ellipk_ratio(k0**2))
+
+
+@partial(jax.jit, inline=True)
+def cpw_thickness_correction(
+    w: sax.FloatArrayLike,
+    s: sax.FloatArrayLike,
+    t: sax.FloatArrayLike,
+    ep_eff: sax.FloatArrayLike,
+) -> tuple[typing.Any, typing.Any]:
+    r"""Apply conductor thickness correction to CPW ε_eff and Z₀.
+
+    First-order correction from Gupta, Garg, Bahl & Bhartia
+
+
+    $$
+    \begin{aligned}
+        \Delta &= \frac{1.25\,t}{\pi}
+    \left(1 + \ln\\frac{4\pi w}{t}\right) \\
+    k_e    &= k_0 + (1 - k_0^2)\,\frac{\Delta}{2s} \\
+    \varepsilon_{\mathrm{eff},t}
+    &= \varepsilon_{\mathrm{eff}}
+    - \frac{0.7\,(\varepsilon_{\mathrm{eff}} - 1)\,t/s}
+    {K(k_0^2)/K(1-k_0^2) + 0.7\,t/s} \\
+    Z_{0,t} &= \frac{30\pi}
+    {\sqrt{\varepsilon_{\mathrm{eff},t}}\;
+    K(k_e^2)/K(1-k_e^2)}
+    \end{aligned}
+    $$
+
+    References:
+        Gupta, Garg, Bahl & Bhartia, §7.3, Eqs. 7.98-7.100
+
+
+    Args:
+        w: Centre-conductor width (m).
+        s: Gap to ground plane (m).
+        t: Conductor thickness (m).
+        ep_eff: Uncorrected effective permittivity.
+
+    Returns:
+        ``(ep_eff_t, z0_t)`` — thickness-corrected effective permittivity
+        and characteristic impedance (Ω).
+    """
+    w = jnp.asarray(w, dtype=float)
+    s = jnp.asarray(s, dtype=float)
+    t = jnp.asarray(t, dtype=float)
+    ep_eff = jnp.asarray(ep_eff, dtype=float)
+
+    k0 = w / (w + 2.0 * s)
+    q0 = ellipk_ratio(k0**2)
+
+    t_safe = jnp.where(t < 1e-15, 1e-15, t)
+    delta = (1.25 * t / jnp.pi) * (1.0 + jnp.log(4.0 * jnp.pi * w / t_safe))
+
+    ke = k0 + (1.0 - k0**2) * delta / (2.0 * s)
+    ke = jnp.clip(ke, 1e-12, 1.0 - 1e-12)
+
+    ep_eff_t = ep_eff - (0.7 * (ep_eff - 1.0) * t / s) / (q0 + 0.7 * t / s)
+    z0_t = 30.0 * jnp.pi / (jnp.sqrt(ep_eff_t) * ellipk_ratio(ke**2))
+
+    ep_eff_t = jnp.where(t <= 0, ep_eff, ep_eff_t)
+    z0_t = jnp.where(t <= 0, cpw_z0(w, s, ep_eff), z0_t)
+
+    return ep_eff_t, z0_t
+
+
+@partial(jax.jit, inline=True)
+def microstrip_epsilon_eff(
+    w: sax.FloatArrayLike,
+    h: sax.FloatArrayLike,
+    ep_r: sax.FloatArrayLike,
+) -> jax.Array:
+    r"""Effective permittivity of a microstrip line.
+
+    Uses the Hammerstad-Jensen formula as given in Pozar.
+
+    $$
+    \varepsilon_{\mathrm{eff}} = \frac{\varepsilon_r + 1}{2}
+        + \frac{\varepsilon_r - 1}{2} \left(\frac{1}{\sqrt{1 + 12h/w}}
+        + 0.04(1 - w/h)^2 \Theta(1 - w/h)\right)
+    $$
+
+    where the last term contributes only for narrow strips ($w/h < 1$).
+
+    References:
+        Hammerstad & Jensen;
+        Pozar, Eqs. 3.195-3.196.
+
+    Args:
+        w: Strip width (m).
+        h: Substrate height (m).
+        ep_r: Relative permittivity of the substrate.
+
+    Returns:
+        Effective permittivity (dimensionless).
+    """
+    w = jnp.asarray(w, dtype=float)
+    h = jnp.asarray(h, dtype=float)
+    ep_r = jnp.asarray(ep_r, dtype=float)
+
+    u = w / h
+    f_u = 1.0 / jnp.sqrt(1.0 + 12.0 / u)
+
+    narrow_correction = 0.04 * (1.0 - u) ** 2
+    f_u = jnp.where(u < 1.0, f_u + narrow_correction, f_u)
+
+    return (ep_r + 1.0) / 2.0 + (ep_r - 1.0) / 2.0 * f_u
+
+
+@partial(jax.jit, inline=True)
+def microstrip_z0(
+    w: sax.FloatArrayLike,
+    h: sax.FloatArrayLike,
+    ep_eff: sax.FloatArrayLike,
+) -> jax.Array:
+    r"""Characteristic impedance of a microstrip line.
+
+    Uses the Hammerstad-Jensen approximation as given in
+    Pozar.
+
+
+    $$
+    \begin{aligned}
+        Z_0 = \begin{cases}
+    \displaystyle\frac{60}{\sqrt{\varepsilon_{\mathrm{eff}}}}
+    \ln\!\left(\frac{8h}{w} + \frac{w}{4h}\right)
+    & w/h \le 1 \\[6pt]
+    \displaystyle\frac{120\pi}
+    {\sqrt{\varepsilon_{\mathrm{eff}}}\,
+    \bigl[w/h + 1.393 + 0.667\ln(w/h + 1.444)\bigr]}
+    & w/h \ge 1
+    \end{cases}
+    \end{aligned}
+    $$
+
+
+    References:
+        Hammerstad & Jensen;
+        Pozar, Eqs. 3.197-3.198.
+
+
+    Args:
+        w: Strip width (m).
+        h: Substrate height (m).
+        ep_eff: Effective permittivity (see :func:`microstrip_epsilon_eff`).
+
+    Returns:
+        Characteristic impedance (Ω).
+    """
+    w = jnp.asarray(w, dtype=float)
+    h = jnp.asarray(h, dtype=float)
+    ep_eff = jnp.asarray(ep_eff, dtype=float)
+
+    u = w / h
+    z_narrow = (60.0 / jnp.sqrt(ep_eff)) * jnp.log(8.0 / u + u / 4.0)
+    z_wide = (
+        120.0 * jnp.pi / (jnp.sqrt(ep_eff) * (u + 1.393 + 0.667 * jnp.log(u + 1.444)))
+    )
+
+    return jnp.where(u <= 1.0, z_narrow, z_wide)
+
+
+@partial(jax.jit, inline=True)
+def microstrip_thickness_correction(
+    w: sax.FloatArrayLike,
+    h: sax.FloatArrayLike,
+    t: sax.FloatArrayLike,
+    ep_r: sax.FloatArrayLike,
+    ep_eff: sax.FloatArrayLike,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    r"""Conductor thickness correction for a microstrip line.
+
+    Uses the widely-adopted Schneider correction as presented in
+    Pozar and Gupta et al.
+
+
+
+    $$
+    \begin{aligned}
+        w_e &= w + \frac{t}{\pi}
+    \ln\frac{4e}{\sqrt{(t/h)^2 + (t/(wPI + 1.1tPI))^2}} \\
+    \varepsilon_{\mathrm{eff},t}
+    &= \varepsilon_{\mathrm{eff}}
+    - \frac{(\varepsilon_r - 1)\,t/h}
+    {4.6\,\sqrt{w/h}}
+    \end{aligned}
+    $$
+
+
+    Then the corrected $Z_0$ is computed with the effective width
+    $w_e$ and corrected $\varepsilon_{\mathrm{eff},t}$.
+
+    References:
+        Pozar, §3.8;
+        Gupta, Garg, Bahl & Bhartia
+
+    Args:
+        w: Strip width (m).
+        h: Substrate height (m).
+        t: Conductor thickness (m).
+        ep_r: Relative permittivity of the substrate.
+        ep_eff: Uncorrected effective permittivity.
+
+    Returns:
+        ``(w_eff, ep_eff_t, z0_t)`` — effective width (m),
+        thickness-corrected effective permittivity,
+        and characteristic impedance (Ω).
+    """
+    w = jnp.asarray(w, dtype=float)
+    h = jnp.asarray(h, dtype=float)
+    t = jnp.asarray(t, dtype=float)
+    ep_r = jnp.asarray(ep_r, dtype=float)
+    ep_eff = jnp.asarray(ep_eff, dtype=float)
+
+    term = jnp.sqrt((t / h) ** 2 + (t / (w * jnp.pi + 1.1 * t * jnp.pi)) ** 2)
+    term_safe = jnp.where(term < 1e-15, 1.0, term)
+    w_eff = w + (t / jnp.pi) * jnp.log(4.0 * jnp.e / term_safe)
+
+    ep_eff_t = ep_eff - (ep_r - 1.0) * t / h / (4.6 * jnp.sqrt(w / h))
+    z0_t = microstrip_z0(w_eff, h, ep_eff_t)
+
+    w_eff = jnp.where(t <= 0, w, w_eff)
+    ep_eff_t = jnp.where(t <= 0, ep_eff, ep_eff_t)
+    z0_t = jnp.where(t <= 0, microstrip_z0(w, h, ep_eff), z0_t)
+
+    return w_eff, ep_eff_t, z0_t
+
+
+@partial(jax.jit, inline=True)
+def propagation_constant(
+    f: sax.FloatArrayLike,
+    ep_eff: sax.FloatArrayLike,
+    tand: sax.FloatArrayLike = 0.0,
+    ep_r: sax.FloatArrayLike = 1.0,
+) -> jax.Array:
+    r"""Complex propagation constant of a quasi-TEM transmission line.
+
+    For the general lossy case
+
+    $$
+    \gamma = \alpha_d + j\,\beta
+    $$
+
+
+
+
+    where the **dielectric attenuation** is
+
+
+
+    $$
+    \alpha_d = \frac{\pi f}{C_M_S}
+    \frac{\varepsilon_r}{\sqrt{\varepsilon_{\mathrm{eff}}}}
+    \frac{\varepsilon_{\mathrm{eff}} - 1}
+    {\varepsilon_r - 1}
+    \tan\delta
+    $$
+
+
+
+
+    and the **phase constant** is
+
+
+
+    $$
+    \beta = \frac{2\pi f}{C_M_S}\,\sqrt{\varepsilon_{\mathrm{eff}}}
+    $$
+
+
+
+
+    For a superconducting line ($\tan\delta = 0$) the propagation
+    is purely imaginary: $\gamma = j\beta$.
+
+    References:
+        Pozar, §3.8
+
+    Args:
+        f: Frequency (Hz).
+        ep_eff: Effective permittivity.
+        tand: Dielectric loss tangent (default 0 — lossless).
+        ep_r: Substrate relative permittivity (only needed when ``tand > 0``).
+
+    Returns:
+        Complex propagation constant $\gamma$ (1/m).
+    """
+    f = jnp.asarray(f, dtype=float)
+    ep_eff = jnp.asarray(ep_eff, dtype=float)
+    tand = jnp.asarray(tand, dtype=float)
+    ep_r = jnp.asarray(ep_r, dtype=float)
+
+    beta = 2.0 * jnp.pi * f * jnp.sqrt(ep_eff) / C_M_S
+
+    denom = jnp.where(jnp.abs(ep_r - 1.0) < 1e-15, 1.0, ep_r - 1.0)
+    alpha_d = (
+        jnp.pi * f / C_M_S * (ep_r / jnp.sqrt(ep_eff)) * ((ep_eff - 1.0) / denom) * tand
+    )
+    alpha_d = jnp.where(jnp.abs(ep_r - 1.0) < 1e-15, 0.0, alpha_d)
+
+    return alpha_d + 1j * beta
+
+
+@partial(jax.jit, inline=True)
+def transmission_line_s_params(
+    gamma: sax.ComplexLike,
+    z0: sax.ComplexLike,
+    length: sax.FloatArrayLike,
+    z_ref: sax.ComplexLike | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    r"""S-parameters of a uniform transmission line (ABCD→S conversion).
+
+    The ABCD matrix of a line with characteristic impedance $Z_0$,
+    propagation constant $\gamma$, and length $\ell$ is:
+
+
+
+    $$
+    \begin{aligned}
+        \begin{pmatrix} A & B \\ C & D \end{pmatrix}
+    = \begin{pmatrix}
+        \cosh\theta & Z_0\sinh\theta \\
+        \sinh\theta / Z_0 & \cosh\theta
+    \end{pmatrix}, \quad \theta = \gamma\ell
+    \end{aligned}
+    $$
+
+
+
+    Converting to S-parameters referenced to $Z_{\mathrm{ref}}$
+
+
+
+    $$
+    \begin{aligned}
+        S_{11} &= \frac{A + B/Z_{\mathrm{ref}} - CZ_{\mathrm{ref}} - D}{A + B/Z_{\mathrm{ref}} + CZ_{\mathrm{ref}} + D} \\
+        S_{21} &= \frac{2}{A + B/Z_{\mathrm{ref}} + CZ_{\mathrm{ref}} + D}
+    \end{aligned}
+    $$
+
+
+
+
+    When ``z_ref`` is ``None`` the reference impedance defaults to ``z0``
+    (matched case), giving $S_{11} = 0$ and
+    $S_{21} = e^{-\gamma\ell}$.
+
+    References:
+        Pozar, Table 4.2
+
+    Args:
+        gamma: Complex propagation constant (1/m).
+        z0: Characteristic impedance (Ω).
+        length: Physical length (m).
+        z_ref: Reference (port) impedance (Ω).  Defaults to ``z0``.
+
+    Returns:
+        ``(S11, S21)`` — complex S-parameter arrays.
+    """
+    gamma_arr = jnp.asarray(gamma, dtype=complex)
+    z0_arr = jnp.asarray(z0, dtype=complex)
+    length_arr = jnp.asarray(length, dtype=float)
+
+    if z_ref is None:
+        z_ref = z0
+    z_ref_arr = jnp.asarray(z_ref, dtype=complex)
+
+    theta = gamma_arr * length_arr
+
+    cosh_t = jnp.cosh(theta)
+    sinh_t = jnp.sinh(theta)
+
+    a = cosh_t
+    b = z0_arr * sinh_t
+    c = sinh_t / z0_arr
+
+    denom = a + b / z_ref_arr + c * z_ref_arr + a
+    s11 = (b / z_ref_arr - c * z_ref_arr) / denom
+    s21 = 2.0 / denom
+
+    return s11, s21
+
+
+@partial(jax.jit, inline=True)
+def coplanar_waveguide(
+    f: sax.FloatArrayLike = DEFAULT_FREQUENCY,
+    length: sax.FloatLike = 1000.0,
+    width: sax.FloatLike = 10.0,
+    gap: sax.FloatLike = 5.0,
+    thickness: sax.FloatLike = 0.0,
+    substrate_thickness: sax.FloatLike = 500.0,
+    ep_r: sax.FloatLike = 11.45,
+    tand: sax.FloatLike = 0.0,
+) -> sax.SDict:
+    r"""S-parameter model for a straight coplanar waveguide.
+
+    Computes S-parameters analytically using conformal-mapping CPW theory
+    following Simons and the Qucs-S CPW model.
+    Conductor thickness corrections use the first-order model of
+    Gupta, Garg, Bahl, and Bhartia.
+
+    References:
+       Simons, ch. 2;
+       Gupta, Garg, Bahl & Bhartia;
+       Qucs technical documentation, §12.4
+
+    Args:
+        f: Array of frequency points in Hz
+        length: Physical length in µm
+        width: Centre-conductor width in µm
+        gap: Gap between centre conductor and ground plane in µm
+        thickness: Conductor thickness in µm
+        substrate_thickness: Substrate height in µm
+        ep_r: Relative permittivity of the substrate
+        tand: Dielectric loss tangent
+
+    Returns:
+        sax.SDict: S-parameters dictionary
+    """
+    f = jnp.asarray(f)
+    f_flat = f.ravel()
+
+    w_m = width * 1e-6
+    s_m = gap * 1e-6
+    t_m = thickness * 1e-6
+    h_m = substrate_thickness * 1e-6
+    length_m = jnp.asarray(length) * 1e-6
+
+    ep_eff = cpw_epsilon_eff(w_m, s_m, h_m, ep_r)
+
+    # Thickness is a scalar, so we use jnp.where to conditionally apply corrections.
+    # Using jnp.where is safe:
+    ep_eff_t, z0_val = cpw_thickness_correction(w_m, s_m, t_m, ep_eff)
+
+    gamma = propagation_constant(f_flat, ep_eff_t, tand=tand, ep_r=ep_r)
+    s11, s21 = transmission_line_s_params(gamma, z0_val, length_m)
+
+    sdict: sax.SDict = {
+        ("o1", "o1"): s11.reshape(f.shape),
+        ("o1", "o2"): s21.reshape(f.shape),
+        ("o2", "o2"): s11.reshape(f.shape),
+    }
+    return sax.reciprocal(sdict)
+
+
+@partial(jax.jit, inline=True)
+def microstrip(
+    f: sax.FloatArrayLike = DEFAULT_FREQUENCY,
+    length: sax.FloatLike = 1000.0,
+    width: sax.FloatLike = 10.0,
+    substrate_thickness: sax.FloatLike = 500.0,
+    thickness: sax.FloatLike = 0.2,
+    ep_r: sax.FloatLike = 11.45,
+    tand: sax.FloatLike = 0.0,
+) -> sax.SDict:
+    r"""S-parameter model for a straight microstrip transmission line.
+
+    Computes S-parameters analytically using the Hammerstad-Jensen closed-form expressions
+    for effective permittivity and characteristic impedance, as described
+    in Pozar.
+    Conductor thickness corrections follow
+    Gupta et al.
+
+    References:
+        Hammerstad & Jensen;
+        Pozar, ch. 3, §3.8;
+        Gupta, Garg, Bahl & Bhartia, §2.2.4
+
+    Args:
+        f: Array of frequency points in Hz.
+        length: Physical length in µm.
+        width: Strip width in µm.
+        substrate_thickness: Substrate height in µm.
+        thickness: Conductor thickness in µm (default 0.2 µm = 200 nm).
+        ep_r: Relative permittivity of the substrate (default 11.45 for Si).
+        tand: Dielectric loss tangent (default 0 — lossless).
+
+    Returns:
+        sax.SDict: S-parameters dictionary.
+    """
+    f = jnp.asarray(f)
+    f_flat = f.ravel()
+
+    w_m = width * 1e-6
+    h_m = substrate_thickness * 1e-6
+    t_m = thickness * 1e-6
+    length_m = jnp.asarray(length) * 1e-6
+
+    ep_eff = microstrip_epsilon_eff(w_m, h_m, ep_r)
+    _w_eff, ep_eff_t, z0_val = microstrip_thickness_correction(
+        w_m, h_m, t_m, ep_r, ep_eff
+    )
+
+    gamma = propagation_constant(f_flat, ep_eff_t, tand=tand, ep_r=ep_r)
+    s11, s21 = transmission_line_s_params(gamma, z0_val, length_m)
+
+    sdict: sax.SDict = {
+        ("o1", "o1"): s11.reshape(f.shape),
+        ("o1", "o2"): s21.reshape(f.shape),
+        ("o2", "o2"): s11.reshape(f.shape),
+    }
+    return sax.reciprocal(sdict)

--- a/src/tests/test_rf_cpw.py
+++ b/src/tests/test_rf_cpw.py
@@ -1,0 +1,233 @@
+"""Tests for CPW electromagnetic analysis functions."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from numpy.testing import assert_allclose
+
+from sax import C_M_S
+
+pytest.importorskip("jaxellip")
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from sax.models.rf import (
+    coplanar_waveguide,
+    cpw_epsilon_eff,
+    cpw_thickness_correction,
+    cpw_z0,
+    ellipk_ratio,
+    propagation_constant,
+    transmission_line_s_params,
+)
+
+
+class TestEllipkRatio:
+    """Tests for the elliptic integral ratio K(m)/K(1-m)."""
+
+    def test_symmetry(self) -> None:
+        """K(m)/K(1-m) = 1 / (K(1-m)/K(m)) → ratio(m) * ratio(1-m) == 1."""
+        m = 0.3
+        assert_allclose(
+            float(ellipk_ratio(m) * ellipk_ratio(1.0 - m)),
+            1.0,
+            atol=1e-10,
+        )
+
+    def test_at_half(self) -> None:
+        """K(0.5) / K(0.5) == 1."""
+        assert_allclose(float(ellipk_ratio(0.5)), 1.0, atol=1e-10)
+
+    @given(m=st.floats(min_value=0.01, max_value=0.99))
+    @settings(deadline=None)
+    def test_positive(self, m: float) -> None:
+        """Ratio should always be positive for 0 < m < 1."""
+        assert float(ellipk_ratio(m)) > 0
+
+
+class TestCPWEpsilonEff:
+    """Tests for CPW effective permittivity."""
+
+    def test_vacuum_substrate(self) -> None:
+        """With ep_r=1 (vacuum), ep_eff should be 1."""
+        ep = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, 1.0)
+        assert_allclose(float(ep), 1.0, atol=1e-6)
+
+    def test_infinite_substrate_limit(self) -> None:
+        """For very thick substrate, ep_eff → (ep_r+1)/2."""
+        ep_r = 11.45
+        # Use very thick substrate (h >> w)
+        ep = cpw_epsilon_eff(10e-6, 6e-6, 100e-3, ep_r)
+        assert_allclose(float(ep), (ep_r + 1) / 2, rtol=1e-4)
+
+    def test_bounded(self) -> None:
+        """1 < ep_eff < ep_r for any substrate."""
+        ep_r = 11.45
+        ep = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, ep_r)
+        assert 1.0 < float(ep) < ep_r
+
+    def test_increases_with_ep_r(self) -> None:
+        """ep_eff should increase with substrate permittivity."""
+        ep1 = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, 4.0)
+        ep2 = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, 11.45)
+        assert float(ep2) > float(ep1)
+
+    def test_jit_compatible(self) -> None:
+        """Function can be JIT-compiled."""
+        jitted = jax.jit(cpw_epsilon_eff)
+        result = jitted(10e-6, 6e-6, 500e-6, 11.45)
+        assert jnp.isfinite(result)
+
+
+class TestCPWZ0:
+    """Tests for CPW characteristic impedance."""
+
+    def test_default_cpw_approx_50_ohm(self) -> None:
+        """Default CPW dimensions (w=10, s=6) should give ~50 Ω."""
+        ep = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, 11.45)
+        z0 = cpw_z0(10e-6, 6e-6, ep)
+        assert_allclose(float(z0), 50.0, atol=2.0)  # within 2 Ω
+
+    def test_narrow_conductor_high_impedance(self) -> None:
+        """Narrow conductor (small w) → high impedance."""
+        ep = cpw_epsilon_eff(1e-6, 20e-6, 500e-6, 11.45)
+        z0 = cpw_z0(1e-6, 20e-6, ep)
+        assert float(z0) > 100.0
+
+    def test_wide_conductor_low_impedance(self) -> None:
+        """Wide conductor (large w) → low impedance."""
+        ep = cpw_epsilon_eff(100e-6, 2e-6, 500e-6, 11.45)
+        z0 = cpw_z0(100e-6, 2e-6, ep)
+        assert float(z0) < 25.0
+
+    def test_jit_compatible(self) -> None:
+        """Function can be JIT-compiled."""
+        jitted = jax.jit(cpw_z0)
+        result = jitted(10e-6, 6e-6, 6.2)
+        assert jnp.isfinite(result)
+
+
+class TestCPWThicknessCorrection:
+    """Tests for GGBB96 conductor thickness correction."""
+
+    def test_thin_conductor_small_correction(self) -> None:
+        """Very thin conductor should produce small corrections."""
+        ep0 = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, 11.45)
+        z0_0 = cpw_z0(10e-6, 6e-6, ep0)
+        ep_t, z0_t = cpw_thickness_correction(10e-6, 6e-6, 1e-9, ep0)
+        # Correction should be small for t = 1 nm
+        assert_allclose(float(ep_t), float(ep0), rtol=0.01)
+        assert_allclose(float(z0_t), float(z0_0), rtol=0.01)
+
+    def test_reduces_impedance(self) -> None:
+        """Thickness correction should reduce Z0 (wider effective conductor)."""
+        ep0 = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, 11.45)
+        z0_0 = cpw_z0(10e-6, 6e-6, ep0)
+        _ep_t, z0_t = cpw_thickness_correction(10e-6, 6e-6, 0.2e-6, ep0)
+        assert float(z0_t) < float(z0_0)
+
+
+class TestPropagationConstant:
+    """Tests for the complex propagation constant."""
+
+    def test_lossless_purely_imaginary(self) -> None:
+        """For tand=0, gamma should be purely imaginary."""
+        gamma = propagation_constant(5e9, 6.225, tand=0.0)
+        assert_allclose(float(jnp.real(gamma)), 0.0, atol=1e-20)
+        assert float(jnp.imag(gamma)) > 0
+
+    def test_phase_velocity(self) -> None:
+        """beta = ω√ep_eff/c_0, so v_p = ω/beta = c_0/√ep_eff."""
+        ep_eff = 6.225
+        f = 5e9
+        gamma = propagation_constant(f, ep_eff)
+        beta = float(jnp.imag(gamma))
+        v_p = 2 * jnp.pi * f / beta
+        assert_allclose(float(v_p), C_M_S / jnp.sqrt(ep_eff), rtol=1e-8)
+
+    def test_lossy_has_real_part(self) -> None:
+        """For tand > 0, gamma should have a positive real part (attenuation)."""
+        gamma = propagation_constant(5e9, 6.225, tand=0.01, ep_r=11.45)
+        assert float(jnp.real(gamma)) > 0
+
+    def test_scales_with_frequency(self) -> None:
+        """beta should scale linearly with frequency."""
+        g1 = propagation_constant(5e9, 6.225)
+        g2 = propagation_constant(10e9, 6.225)
+        assert_allclose(
+            float(jnp.imag(g2)),
+            2.0 * float(jnp.imag(g1)),
+            rtol=1e-8,
+        )
+
+
+class TestTransmissionLineSParams:
+    """Tests for ABCD→S-parameter conversion."""
+
+    def test_zero_length_identity(self) -> None:
+        """Zero-length line → S11=0, S21=1."""
+        gamma = 1j * 100.0
+        s11, s21 = transmission_line_s_params(gamma, 50.0, 0.0)
+        assert_allclose(float(jnp.abs(s11)), 0.0, atol=1e-10)
+        assert_allclose(float(jnp.abs(s21)), 1.0, atol=1e-10)
+
+    def test_matched_impedance_no_reflection(self) -> None:
+        """With z_ref = z0, S11 should be zero."""
+        gamma = jnp.array([1j * 100.0])
+        s11, _ = transmission_line_s_params(gamma, 50.0, 0.001)
+        assert_allclose(float(jnp.abs(s11[0])), 0.0, atol=1e-10)
+
+    def test_mismatched_impedance_reflection(self) -> None:
+        """With z_ref ≠ z0, S11 should be non-zero."""
+        gamma = jnp.array([1j * 100.0])
+        s11, _ = transmission_line_s_params(gamma, 50.0, 0.1, z_ref=75.0)
+        assert float(jnp.abs(s11[0])) > 0.01
+
+    def test_lossless_passivity(self) -> None:
+        """For lossless line: |S11|² + |S21|² = 1."""
+        gamma = jnp.array([1j * 200.0])
+        s11, s21 = transmission_line_s_params(gamma, 50.0, 0.01, z_ref=75.0)
+        power = jnp.abs(s11) ** 2 + jnp.abs(s21) ** 2
+        assert_allclose(float(power[0]), 1.0, atol=1e-10)
+
+    def test_reciprocal(self) -> None:
+        """S21 = S12 for a reciprocal 2-port network."""
+        gamma = jnp.array([1j * 150.0])
+        z0 = 50.0
+        length = 0.02
+        z_ref = 75.0
+        _s11, s21 = transmission_line_s_params(gamma, z0, length, z_ref=z_ref)
+
+        theta = gamma * length
+        a = jnp.cosh(theta)
+        b = z0 * jnp.sinh(theta)
+        c = jnp.sinh(theta) / z0
+        d = a
+
+        denom = a + b / z_ref + c * z_ref + d
+        s12_expected = 2.0 / denom
+
+        assert_allclose(s21, s12_expected, atol=1e-10)
+        assert jnp.isfinite(s21[0])
+
+
+class TestStraightJIT:
+    """Tests for JIT compilation of the straight CPW model."""
+
+    def test_straight_matches_non_jit(self) -> None:
+        """JIT-compiled straight should give same results as non-JIT."""
+        f = jnp.linspace(4e9, 8e9, 10)
+
+        result_nojit = coplanar_waveguide(f=f, length=1000)
+
+        jitted_inner = jax.jit(lambda f, length: coplanar_waveguide(f=f, length=length))
+        result_jit = jitted_inner(f, 1000.0)
+
+        for key in result_nojit:
+            assert_allclose(
+                result_nojit[key],
+                result_jit[key],
+                atol=1e-10,
+                err_msg=f"Mismatch for {key}",
+            )

--- a/src/tests/test_rf_microstrip.py
+++ b/src/tests/test_rf_microstrip.py
@@ -1,0 +1,125 @@
+"""Tests for microstrip electromagnetic analysis functions."""
+
+import jax
+import jax.numpy as jnp
+from numpy.testing import assert_allclose
+
+from sax.models.rf import (
+    microstrip as straight_microstrip,
+)
+from sax.models.rf import (
+    microstrip_epsilon_eff,
+    microstrip_thickness_correction,
+    microstrip_z0,
+)
+
+
+class TestMicrostripEpsilonEff:
+    """Tests for microstrip effective permittivity."""
+
+    def test_vacuum_substrate(self) -> None:
+        """With ep_r=1, ep_eff should be 1."""
+        ep = microstrip_epsilon_eff(10e-6, 500e-6, 1.0)
+        assert_allclose(float(ep), 1.0, atol=1e-10)
+
+    def test_bounded(self) -> None:
+        """1 < ep_eff < ep_r for any substrate."""
+        ep_r = 11.45
+        ep = microstrip_epsilon_eff(10e-6, 500e-6, ep_r)
+        assert 1.0 < float(ep) < ep_r
+
+    def test_wide_strip_approaches_ep_r(self) -> None:
+        """For very wide strips (w/h >> 1), ep_eff → ep_r."""
+        ep_r = 11.45
+        ep = microstrip_epsilon_eff(1e-3, 1e-6, ep_r)  # w/h = 1000
+        assert float(ep) > 0.9 * ep_r
+
+    def test_narrow_strip_approaches_average(self) -> None:
+        """For very narrow strips (w/h << 1), ep_eff → (ep_r+1)/2."""
+        ep_r = 11.45
+        ep = microstrip_epsilon_eff(1e-9, 1e-3, ep_r)  # w/h = 1e-6
+        assert_allclose(float(ep), (ep_r + 1) / 2, rtol=0.1)
+
+    def test_increases_with_width(self) -> None:
+        """ep_eff increases as strip gets wider (more field in substrate)."""
+        ep1 = microstrip_epsilon_eff(5e-6, 500e-6, 11.45)
+        ep2 = microstrip_epsilon_eff(100e-6, 500e-6, 11.45)
+        assert float(ep2) > float(ep1)
+
+
+class TestMicrostripZ0:
+    """Tests for microstrip characteristic impedance."""
+
+    def test_narrow_strip_high_impedance(self) -> None:
+        """Narrow strip (w/h < 1) → high impedance."""
+        ep = microstrip_epsilon_eff(1e-6, 500e-6, 11.45)
+        z0 = microstrip_z0(1e-6, 500e-6, ep)
+        assert float(z0) > 100.0
+
+    def test_wide_strip_low_impedance(self) -> None:
+        """Wide strip (w/h >> 1) → low impedance."""
+        ep = microstrip_epsilon_eff(1e-3, 500e-6, 11.45)
+        z0 = microstrip_z0(1e-3, 500e-6, ep)
+        assert float(z0) < 35.0
+
+    def test_typical_50_ohm(self) -> None:
+        r"""A common 50 Ω microstrip on alumina (ep_r=9.8, h=0.635mm) has w ≈ 0.6mm."""
+        ep = microstrip_epsilon_eff(0.6e-3, 0.635e-3, 9.8)
+        z0 = microstrip_z0(0.6e-3, 0.635e-3, ep)
+        assert_allclose(float(z0), 50.0, atol=5.0)
+
+    def test_jit_compatible(self) -> None:
+        """Function can be JIT-compiled."""
+        jitted = jax.jit(microstrip_z0)
+        result = jitted(10e-6, 500e-6, 6.2)
+        assert jnp.isfinite(result)
+
+
+class TestMicrostripThicknessCorrection:
+    """Tests for microstrip conductor thickness correction."""
+
+    def test_reduces_impedance(self) -> None:
+        """Thickness correction should reduce Z0 (wider effective strip)."""
+        ep0 = microstrip_epsilon_eff(10e-6, 500e-6, 11.45)
+        z0_0 = microstrip_z0(10e-6, 500e-6, ep0)
+        _, _ep_t, z0_t = microstrip_thickness_correction(
+            10e-6, 500e-6, 0.2e-6, 11.45, ep0
+        )
+        assert float(z0_t) < float(z0_0)
+
+
+class TestStraightMicrostrip:
+    """Tests for the straight_microstrip model."""
+
+    def test_zero_length_transmission(self) -> None:
+        """Zero-length microstrip → near-unity transmission."""
+        f = jnp.array([5e9])
+        result = straight_microstrip(f=f, length=0.0)
+        s21 = jnp.abs(result[("o1", "o2")])
+        assert_allclose(float(s21.squeeze()), 1.0, atol=1e-6)
+
+    def test_phase_shift_increases_with_length(self) -> None:
+        """Longer lines should have more phase shift."""
+        f = jnp.array([5e9])
+        r1 = straight_microstrip(f=f, length=1000)
+        r2 = straight_microstrip(f=f, length=2000)
+        phase1 = jnp.angle(r1[("o1", "o2")]).squeeze()
+        phase2 = jnp.angle(r2[("o1", "o2")]).squeeze()
+        # Phase shift roughly doubles (unwrapped)
+        assert jnp.abs(phase2) > jnp.abs(phase1) - 0.01
+
+    def test_lossy_attenuates(self) -> None:
+        """With tand > 0, transmission should be reduced."""
+        f = jnp.array([5e9])
+        r_lossless = straight_microstrip(f=f, length=10000, tand=0.0)
+        r_lossy = straight_microstrip(f=f, length=10000, tand=0.01)
+        s21_ll = jnp.abs(r_lossless[("o1", "o2")]).squeeze()
+        s21_ly = jnp.abs(r_lossy[("o1", "o2")]).squeeze()
+        assert float(s21_ly) < float(s21_ll)
+
+    def test_jit_compatible(self) -> None:
+        """Microstrip straight model can be JIT-compiled."""
+        jitted = jax.jit(lambda f, length: straight_microstrip(f=f, length=length))
+        f = jnp.array([5e9])
+        result = jitted(f, 1000.0)
+        assert jnp.isfinite(result[("o1", "o2")])


### PR DESCRIPTION
This PR introduces JAX-jittable RF waveguide models for Coplanar Waveguides (CPW) and Microstrip lines from https://github.com/gdsfactory/quantum-rf-pdk/blob/main/qpdk/models/cpw.py

### Key Changes:
- Added `coplanar_waveguide` and `microstrip` models to `sax.models.rf`.
- Implemented analytical formulas for characteristic impedance, effective permittivity, and thickness corrections based on standard literature (Simons, Pozar, Gupta et al.).
- Added complex propagation constant and ABCD-to-S-parameter conversion for uniform transmission lines.
- Introduced `rf` optional dependency and `jaxellip` for elliptic integral computations.
- Added comprehensive unit tests and documentation with theory references.