### PR TITLE
Add bibtex-tidy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
       - id: pretty-format-toml
         args: [--autofix]
 
+  - repo: https://github.com/FlamingTempura/bibtex-tidy
+    rev: v1.14.0
+    hooks:
+      - id: bibtex-tidy
+        args: ['--align=1', '--curly', '--months', '--sort', '--duplicates', '--strip-enclosing-braces']
+
   - repo: local
     hooks:
       - id: nbclean

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,35 +1,35 @@
-@book{python,
-  title={Python reference manual},
-  author={Van Rossum, Guido and Drake Jr, Fred L},
-  year={1995},
-  publisher={Centrum voor Wiskunde en Informatica Amsterdam}
-}
-@misc{pythonformaths,
-    title={Python for Maths},
-    author={Andreas Ernst},
-    booktitle={github},
-    year={2021},
-    url={https://github.erc.monash.edu.au/andrease/Python4Maths}
-}
-@misc{python-loops,
-    title={Loop like a native},
-    author={Ned Batchelder},
-    booktitle={PyCon},
-    year={2013},
-    url={https://www.youtube.com/watch?v=EnSu9hHGq5o&t=1519s}
-}
 @misc{numpy-docs,
-    title={Numpy Documentation},
-    author={Travis Oliphant},
-    booktitle={Numpy},
-    year={2006},
-    url={https://numpy.org/doc/stable/index.html}
+  title = {Numpy Documentation},
+  author = {Travis Oliphant},
+  booktitle = {Numpy},
+  year = {2006},
+  url = {https://numpy.org/doc/stable/index.html}
 }
 @book{pozar-2012,
-    title={Microwave {{Engineering}}},
-    author={M. Pozar, David},
-    year={2012},
-    edition={4},
-    publisher={John Wiley \& Sons, Inc.},
-    isbn={978-0-470-63155-3}
+  title = {Microwave {{Engineering}}},
+  author = {M. Pozar, David},
+  year = {2012},
+  edition = {4},
+  publisher = {John Wiley \& Sons, Inc.},
+  isbn = {978-0-470-63155-3}
+}
+@book{python,
+  title = {Python reference manual},
+  author = {Van Rossum, Guido and Drake Jr, Fred L},
+  year = {1995},
+  publisher = {Centrum voor Wiskunde en Informatica Amsterdam}
+}
+@misc{python-loops,
+  title = {Loop like a native},
+  author = {Ned Batchelder},
+  booktitle = {PyCon},
+  year = {2013},
+  url = {https://www.youtube.com/watch?v=EnSu9hHGq5o&t=1519s}
+}
+@misc{pythonformaths,
+  title = {Python for Maths},
+  author = {Andreas Ernst},
+  booktitle = {github},
+  year = {2021},
+  url = {https://github.erc.monash.edu.au/andrease/Python4Maths}
 }


### PR DESCRIPTION
This PR adds the `bibtex-tidy` pre-commit hook to maintain consistent formatting in BibTeX files. This change also includes the initial reformatting of `docs/references.bib`.