### PR TITLE
docs: switch theme from mkdocs-material to mkdocs-shadcn

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,35 +7,10 @@ repo_name: flaport/sax
 copyright: Copyright © 2025, Floris Laporte, Apache-2.0
 
 theme:
-  name: material
+  name: shadcn
   logo: assets/logo.svg
   favicon: assets/favicon.ico
-  font:
-    text: Roboto
-    code: Roboto Mono
-  palette:
-    - media: "(prefers-color-scheme)"
-      toggle:
-        icon: material/brightness-auto
-        name: Switch to light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      toggle:
-        icon: material/weather-sunny
-        name: Switch to dark mode
-      primary: blue
-      accent: deep purple
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      toggle:
-        icon: material/weather-night
-        name: Switch to system default
-      primary: blue
-      accent: deep purple
-  features:
-    - content.code.copy
-    - navigation.footer
-  search: true
+  katex_options: {}
 
 nav:
   - home: index.md
@@ -64,12 +39,6 @@ nav:
       - sax.models: models.md
       - sax.models.rf: models_rf.md
   - changelog: changelog.md
-
-extra_css:
-  - assets/custom.css
-
-extra_javascript:
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:
   - search
@@ -136,8 +105,3 @@ markdown_extensions:
 
 hooks:
   - docs/hooks.py
-
-extra:
-  social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/flaport

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,15 @@ theme:
   name: shadcn
   logo: assets/logo.svg
   favicon: assets/favicon.ico
+  pygments_style:
+    light: shadcn-light
+    dark: github-dark
   katex_options: {}
+  crossref_modules:
+    - sax
+    - sax.fit
+    - sax.models
+    - sax.models.rf
 
 nav:
   - home: index.md
@@ -87,7 +95,8 @@ markdown_extensions:
   - footnotes
   - toc:
         permalink: true
-  - pymdownx.emoji
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -97,11 +106,10 @@ markdown_extensions:
   - pymdownx.magiclink
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.superfences
   - admonition
   - pymdownx.details
-  - pymdownx.arithmatex:
-      generic: true
-  - pymdownx.superfences
+  - pymdownx.emoji
 
 hooks:
   - docs/hooks.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ docs = [
   "mkautodoc>=0.2.0,<0.3.0",
   "mkdocs-autorefs>=1.4.4,<1.5.0",
   "mkdocs-bibtex>=4.4.0,<5.0.0",
-  "mkdocs-material>=9.7.6,<10.0.0",
+  "mkdocs-shadcn @ git+https://github.com/gdsfactory/mkdocs-shadcn.git",
   "mkdocs-matplotlib>=0.10.1,<0.11.0",
   "mkdocs>=1.6.1,<2.0.0",
   "mkdocstrings[python]>=1.0.4,<2.0.0",


### PR DESCRIPTION
Switch the docs theme from `mkdocs-material` to `mkdocs-shadcn` (via `gdsfactory/mkdocs-shadcn`), matching the setup used in `flaport/meow`.

**Changes:**
- `mkdocs.yml`: replace `material` theme block with `shadcn` (logo, favicon, `katex_options: {}`); remove material-specific `extra_css`, `extra_javascript` (MathJax CDN), and `extra` (social links)
- `pyproject.toml`: replace `mkdocs-material` in the `docs` dependency group with `mkdocs-shadcn @ git+https://github.com/gdsfactory/mkdocs-shadcn.git`