### PR TITLE
Add more unit tests for RF models and transmission line components

### DIFF
--- a/src/tests/test_rf_cpw.py
+++ b/src/tests/test_rf_cpw.py
@@ -127,6 +127,14 @@ class TestCPWThicknessCorrection:
         _ep_t, z0_t = cpw_thickness_correction(10e-6, 6e-6, 0.2e-6, ep0)
         assert float(z0_t) < float(z0_0)
 
+    def test_thickness_zero(self) -> None:
+        """With thickness=0, results should match the uncorrected case."""
+        ep0 = cpw_epsilon_eff(10e-6, 6e-6, 500e-6, 11.45)
+        ep_t, z0_t = cpw_thickness_correction(10e-6, 6e-6, 0.0, ep0)
+        z0_0 = cpw_z0(10e-6, 6e-6, ep0)
+        assert_allclose(float(ep_t), float(ep0), rtol=1e-10)
+        assert_allclose(float(z0_t), float(z0_0), rtol=1e-10)
+
 
 class TestPropagationConstant:
     """Tests for the complex propagation constant."""
@@ -214,6 +222,13 @@ class TestTransmissionLineSParams:
 
 class TestStraightJIT:
     """Tests for JIT compilation of the straight CPW model."""
+
+    def test_zero_length(self) -> None:
+        """Zero-length CPW → near-unity transmission."""
+        f = jnp.array([5e9])
+        result = coplanar_waveguide(f=f, length=0.0)
+        s21 = jnp.abs(result[("o1", "o2")])
+        assert_allclose(float(s21.squeeze()), 1.0, atol=1e-6)
 
     def test_straight_matches_non_jit(self) -> None:
         """JIT-compiled straight should give same results as non-JIT."""

--- a/src/tests/test_rf_microstrip.py
+++ b/src/tests/test_rf_microstrip.py
@@ -87,6 +87,14 @@ class TestMicrostripThicknessCorrection:
         )
         assert float(z0_t) < float(z0_0)
 
+    def test_thickness_zero(self) -> None:
+        """With thickness=0, results should match the uncorrected case."""
+        ep0 = microstrip_epsilon_eff(10e-6, 500e-6, 11.45)
+        _, ep_t, z0_t = microstrip_thickness_correction(10e-6, 500e-6, 0.0, 11.45, ep0)
+        z0_0 = microstrip_z0(10e-6, 500e-6, ep0)
+        assert_allclose(float(ep_t), float(ep0), rtol=1e-10)
+        assert_allclose(float(z0_t), float(z0_0), rtol=1e-10)
+
 
 class TestStraightMicrostrip:
     """Tests for the straight_microstrip model."""

--- a/src/tests/test_rf_models.py
+++ b/src/tests/test_rf_models.py
@@ -103,13 +103,35 @@ class TestRFModels:
             expected_value = 1 if i == j else 0
             self._assert_s_param(s, (f"o{i}", f"o{j}"), expected_value)
 
-    def test_lc_shunt_component(self, freq_array: jnp.ndarray) -> None:
-        """Test LC shunt component circuit."""
+    def test_resistor(self, freq_single: float) -> None:
+        """Test resistor element."""
+        s = rf.resistor(f=freq_single, resistance=100, z0=50)
+
+        self._assert_s_params_dict(s, expected_shape=())
+        # S11 = R / (R + 2*Z0) = 100 / (100 + 100) = 0.5
+        self._assert_s_param(s, ("o1", "o1"), 0.5)
+
+    def test_lc_shunt_component(self) -> None:
+        """Test LC shunt component circuit resonance."""
+        L = 1e-9
+        C = 1e-12
+        f0 = 1 / (2 * jnp.pi * jnp.sqrt(L * C))
+        f = jnp.array([f0 * 0.5, f0, f0 * 2.0])
+
         s = rf.lc_shunt_component(
-            f=freq_array,
-            inductance=1e-9,
-            capacitance=1e-12,
+            f=f,
+            inductance=L,
+            capacitance=C,
             z0=50,
         )
 
-        self._assert_s_params_dict(s, expected_shape=(len(freq_array),))
+        self._assert_s_params_dict(s, expected_shape=(3,))
+        # At resonance, S11 should be 1.0 (open circuit for shunted parallel LC)
+        assert jnp.abs(s[("o1", "o1")][1]) > 0.99
+
+    def test_multidimensional_frequency(self) -> None:
+        """Test models with multidimensional frequency arrays."""
+        f = jnp.linspace(1e9, 10e9, 12).reshape(3, 4)
+        s = rf.gamma_0_load(f=f, gamma_0=0.5, n_ports=1)
+        assert s[("o1", "o1")].shape == (3, 4)
+        assert jnp.allclose(s[("o1", "o1")], 0.5)


### PR DESCRIPTION
                                                                                     
This PR improves the test coverage for the RF module, specifically targeting transmission line component thickness and bare resistors.                                                                                                   
                                                                                                                                           
### Changes
 - RF Models: Added unit tests for resistor and expanded the lc_shunt_component test to verify physical resonance behavior (S11 magnitude  
   at resonance).                                                                                                                          
 - CPW & Microstrip: Added boundary case tests for zero-conductor thickness and zero-physical length to ensure numerical stability and     
   correct uncorrected behavior.                                                                                                           
 - Robustness: Added verification for models using multi-dimensional frequency arrays to ensure consistent behavior across different input 
   shapes.                                                                                                                                 