### PR TITLE
Add missing notebooks to the navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,8 @@ nav:
       - hierarchical circuits: nbs/examples/11_hierarchical_circuits.md
       - data parsers: nbs/examples/12_data_parsers.md
       - surface models: nbs/examples/13_surface_models.md
+      - probes: nbs/examples/14_probes.md
+      - multi link: nbs/examples/15_multi_link.md
   - internals:
       - backends: nbs/internals/03_backends.md
       - circuit: nbs/internals/02_circuit.md


### PR DESCRIPTION
There are a few notebooks in the ``nbs/`` folder that:

1) are useful (especially the probes example),
2) are built during docs generation, and therefore show up in search feature, but:
3) are not in the docs navigation bar

This pull request simply adds them. I assume they are complete and not adding them was simply an oversight?