### PR TITLE
fix: reject complex RF dielectric parameters

### DIFF
--- a/src/sax/models/rf.py
+++ b/src/sax/models/rf.py
@@ -4,6 +4,10 @@ This module provides generic RF components and JAX-jittable functions for
 computing the characteristic impedance, effective permittivity, and
 propagation constant of coplanar waveguides and microstrip lines.
 
+Dielectric parameters ``ep_r``, ``ep_eff``, and ``tand`` must be real.
+Complex inputs raise ``TypeError``; specify dielectric loss using a real
+``tand`` together with real permittivity.
+
 Note:
     Some models in this module require the ``jaxellip`` package.
     Install the ``rf`` extra to include it: ``pip install sax[rf]``.
@@ -469,6 +473,14 @@ def ellipk_ratio(m: sax.FloatArrayLike) -> jax.Array:
     return jaxellip.ellipk(m_arr) / jaxellip.ellipk(1 - m_arr)
 
 
+def _as_real_dielectric(value: sax.FloatArrayLike, name: str) -> jax.Array:
+    """Reject complex dielectric inputs before converting to a real array."""
+    if jnp.iscomplexobj(value):
+        msg = f"{name} must be real; use a real tand to specify dielectric loss"
+        raise TypeError(msg)
+    return jnp.asarray(value, dtype=float)
+
+
 @partial(jax.jit, inline=True)
 def cpw_epsilon_eff(
     w: sax.FloatArrayLike,
@@ -506,7 +518,7 @@ def cpw_epsilon_eff(
     w = jnp.asarray(w, dtype=float)
     s = jnp.asarray(s, dtype=float)
     h = jnp.asarray(h, dtype=float)
-    ep_r = jnp.asarray(ep_r, dtype=float)
+    ep_r = _as_real_dielectric(ep_r, "ep_r")
     k0 = w / (w + 2.0 * s)
     k1 = jnp.sinh(jnp.pi * w / (4.0 * h)) / jnp.sinh(jnp.pi * (w + 2.0 * s) / (4.0 * h))
     q1 = ellipk_ratio(k1**2) / ellipk_ratio(k0**2)
@@ -540,7 +552,7 @@ def cpw_z0(
     """
     w = jnp.asarray(w, dtype=float)
     s = jnp.asarray(s, dtype=float)
-    ep_eff = jnp.asarray(ep_eff, dtype=float)
+    ep_eff = _as_real_dielectric(ep_eff, "ep_eff")
     k0 = w / (w + 2.0 * s)
     return 30.0 * jnp.pi / (jnp.sqrt(ep_eff) * ellipk_ratio(k0**2))
 
@@ -589,7 +601,7 @@ def cpw_thickness_correction(
     w = jnp.asarray(w, dtype=float)
     s = jnp.asarray(s, dtype=float)
     t = jnp.asarray(t, dtype=float)
-    ep_eff = jnp.asarray(ep_eff, dtype=float)
+    ep_eff = _as_real_dielectric(ep_eff, "ep_eff")
 
     k0 = w / (w + 2.0 * s)
     q0 = ellipk_ratio(k0**2)
@@ -641,7 +653,7 @@ def microstrip_epsilon_eff(
     """
     w = jnp.asarray(w, dtype=float)
     h = jnp.asarray(h, dtype=float)
-    ep_r = jnp.asarray(ep_r, dtype=float)
+    ep_r = _as_real_dielectric(ep_r, "ep_r")
 
     u = w / h
     f_u = 1.0 / jnp.sqrt(1.0 + 12.0 / u)
@@ -694,7 +706,7 @@ def microstrip_z0(
     """
     w = jnp.asarray(w, dtype=float)
     h = jnp.asarray(h, dtype=float)
-    ep_eff = jnp.asarray(ep_eff, dtype=float)
+    ep_eff = _as_real_dielectric(ep_eff, "ep_eff")
 
     u = w / h
     z_narrow = (60.0 / jnp.sqrt(ep_eff)) * jnp.log(8.0 / u + u / 4.0)
@@ -754,8 +766,8 @@ def microstrip_thickness_correction(
     w = jnp.asarray(w, dtype=float)
     h = jnp.asarray(h, dtype=float)
     t = jnp.asarray(t, dtype=float)
-    ep_r = jnp.asarray(ep_r, dtype=float)
-    ep_eff = jnp.asarray(ep_eff, dtype=float)
+    ep_r = _as_real_dielectric(ep_r, "ep_r")
+    ep_eff = _as_real_dielectric(ep_eff, "ep_eff")
 
     term = jnp.sqrt((t / h) ** 2 + (t / (w * jnp.pi + 1.1 * t * jnp.pi)) ** 2)
     term_safe = jnp.where(term < 1e-15, 1.0, term)
@@ -824,16 +836,16 @@ def propagation_constant(
     Args:
         f: Frequency (Hz).
         ep_eff: Effective permittivity.
-        tand: Dielectric loss tangent (default 0 — lossless).
+        tand: Real dielectric loss tangent (default 0 — lossless).
         ep_r: Substrate relative permittivity (only needed when ``tand > 0``).
 
     Returns:
         Complex propagation constant $\gamma$ (1/m).
     """
     f = jnp.asarray(f, dtype=float)
-    ep_eff = jnp.asarray(ep_eff, dtype=float)
-    tand = jnp.asarray(tand, dtype=float)
-    ep_r = jnp.asarray(ep_r, dtype=float)
+    ep_eff = _as_real_dielectric(ep_eff, "ep_eff")
+    tand = _as_real_dielectric(tand, "tand")
+    ep_r = _as_real_dielectric(ep_r, "ep_r")
 
     beta = 2.0 * jnp.pi * f * jnp.sqrt(ep_eff) / C_M_S
 
@@ -957,8 +969,8 @@ def coplanar_waveguide(
         gap: Gap between centre conductor and ground plane in µm
         thickness: Conductor thickness in µm
         substrate_thickness: Substrate height in µm
-        ep_r: Relative permittivity of the substrate
-        tand: Dielectric loss tangent
+        ep_r: Real relative permittivity of the substrate
+        tand: Real dielectric loss tangent
 
     Returns:
         sax.SDict: S-parameters dictionary
@@ -1018,8 +1030,8 @@ def microstrip(
         width: Strip width in µm.
         substrate_thickness: Substrate height in µm.
         thickness: Conductor thickness in µm (default 0.2 µm = 200 nm).
-        ep_r: Relative permittivity of the substrate (default 11.45 for Si).
-        tand: Dielectric loss tangent (default 0 — lossless).
+        ep_r: Real relative permittivity of the substrate (default 11.45 for Si).
+        tand: Real dielectric loss tangent (default 0 — lossless).
 
     Returns:
         sax.SDict: S-parameters dictionary.

--- a/src/tests/test_rf_dielectric_inputs.py
+++ b/src/tests/test_rf_dielectric_inputs.py
@@ -1,0 +1,87 @@
+"""Regression tests for real-only RF dielectric parameters."""
+
+from collections.abc import Callable
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from sax.models import rf
+
+
+@pytest.mark.parametrize("disable_jit", [True, False])
+@pytest.mark.parametrize(
+    "value",
+    [
+        11.9 - 0.119j,
+        11.9 + 0j,
+        np.complex128(11.9 - 0.119j),
+        np.array([11.9, 11.9 - 0.119j]),
+        jnp.array([11.9, 11.9 - 0.119j]),
+    ],
+    ids=["python", "zero-imaginary", "numpy-scalar", "numpy-array", "jax-array"],
+)
+@pytest.mark.parametrize(
+    ("model", "parameter"),
+    [
+        (partial(rf.cpw_epsilon_eff, 20e-6, 15e-6, 100e-6), "ep_r"),
+        (partial(rf.cpw_z0, 20e-6, 15e-6), "ep_eff"),
+        (partial(rf.cpw_thickness_correction, 20e-6, 15e-6, 0.2e-6), "ep_eff"),
+        (partial(rf.microstrip_epsilon_eff, 20e-6, 100e-6), "ep_r"),
+        (partial(rf.microstrip_z0, 20e-6, 100e-6), "ep_eff"),
+        (
+            partial(
+                rf.microstrip_thickness_correction, 20e-6, 100e-6, 0.2e-6, ep_eff=6.0
+            ),
+            "ep_r",
+        ),
+        (
+            partial(
+                rf.microstrip_thickness_correction, 20e-6, 100e-6, 0.2e-6, ep_r=11.9
+            ),
+            "ep_eff",
+        ),
+        (partial(rf.propagation_constant, 1e9), "ep_eff"),
+        (partial(rf.propagation_constant, 1e9, 6.0), "ep_r"),
+        (partial(rf.propagation_constant, 1e9, 6.0), "tand"),
+        (rf.coplanar_waveguide, "ep_r"),
+        (rf.coplanar_waveguide, "tand"),
+        (rf.microstrip, "ep_r"),
+        (rf.microstrip, "tand"),
+    ],
+)
+def test_rejects_complex_dielectric_parameters(
+    model: Callable,
+    parameter: str,
+    value: complex | np.ndarray | jax.Array,
+    *,
+    disable_jit: bool,
+) -> None:
+    with (
+        jax.disable_jit(disable_jit),
+        pytest.raises(TypeError, match=rf"{parameter} must be real; .*tand"),
+    ):
+        model(**{parameter: value})
+
+
+@pytest.mark.parametrize("model", [rf.coplanar_waveguide, rf.microstrip])
+@pytest.mark.parametrize("disable_jit", [True, False])
+@pytest.mark.parametrize("tand", [0.01, np.array([0.001, 0.01, 0.03])])
+def test_real_loss_tangent_attenuates(
+    model: Callable, tand: float | np.ndarray, *, disable_jit: bool
+) -> None:
+    f = np.array([1e9, 10e9, 100e9])
+    with jax.disable_jit(disable_jit):
+        lossless = model(f=f, ep_r=11.9, tand=0.0)
+        lossy = model(f=f, ep_r=11.9, tand=tand)
+        scalar_results = [
+            model(f=frequency, ep_r=11.9, tand=loss)["o1", "o2"]
+            for frequency, loss in zip(f, np.broadcast_to(tand, f.shape), strict=True)
+        ]
+
+    assert_allclose(np.abs(lossless["o1", "o2"]), 1.0, atol=1e-12)
+    assert np.all(np.abs(lossy["o1", "o2"]) < 1.0)
+    assert_allclose(lossy["o1", "o2"], scalar_results, rtol=1e-12)


### PR DESCRIPTION
Passing complex permittivity to `coplanar_waveguide` silently discarded dielectric loss and returned a lossless S-matrix. Reject complex `ep_r`, `ep_eff`, and `tand` before real conversion in the CPW, microstrip, and propagation helpers, with a `TypeError` directing callers to real permittivity and a real `tand`. The dtype check also applies during JAX tracing, including complex inputs with a zero imaginary part.

Add regression coverage for Python, NumPy, and JAX complex inputs in eager and JIT execution, plus checks that real scalar and frequency-dependent loss tangents still attenuate both transmission-line models correctly. Document the real-only dielectric parameters.

Validation: all 204 RF tests passed, including 148 new regression cases; all applicable pre-commit hooks passed, including Ruff and Pyright. Confirmed a regression test failed before applying the fix.

Closes #124.
